### PR TITLE
oracle-primenumber: added checkCommandVisibility to oracle service

### DIFF
--- a/Features/oracle-primenumber/service-kotlin/src/main/kotlin/net/corda/examples/oracle/service/service/Oracle.kt
+++ b/Features/oracle-primenumber/service-kotlin/src/main/kotlin/net/corda/examples/oracle/service/service/Oracle.kt
@@ -75,6 +75,12 @@ class Oracle(val services: ServiceHub) : SingletonSerializeAsToken() {
         // Is it a Merkle tree we are willing to sign over?
         val isValidMerkleTree = ftx.checkWithFun(::isCommandWithCorrectPrimeAndIAmSigner)
 
+        /**
+         * Function that checks if all of the commands that should be signed by the input public key are visible.
+         * This functionality is required from Oracles to check that all of the commands they should sign are visible.
+         */
+        ftx.checkCommandVisibility(services.myInfo.legalIdentities.first().owningKey);
+
         if (isValidMerkleTree) {
             return services.createSignature(ftx, myKey)
         } else {


### PR DESCRIPTION
Adds a needed security based check for oracles. checks that in filtered transaction all commands requiring the oracle signature are visible. Without, it's possible to attack by embedding >1 command in a TX for oracle to sign, then filtering down to a "valid" - oracle will sign the TX (unknowingly vouching for the hidden commands as well).