### PR TITLE
Fix broken gradle repo URL 

### DIFF
--- a/Accounts/supplychain/build.gradle
+++ b/Accounts/supplychain/build.gradle
@@ -50,7 +50,7 @@ allprojects {
         //SDK lib
         maven { url 'https://software.r3.com/artifactory/corda-lib' }
         //Gradle Plugins
-        maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+        maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/Accounts/tictacthor/build.gradle
+++ b/Accounts/tictacthor/build.gradle
@@ -55,7 +55,7 @@ allprojects {
         //SDK lib
         maven { url 'https://software.r3.com/artifactory/corda-lib' }
         //Gradle Plugins
-        maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+        maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/Advanced/auction-cordapp/repositories.gradle
+++ b/Advanced/auction-cordapp/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Advanced/duediligence-cordapp/repositories.gradle
+++ b/Advanced/duediligence-cordapp/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Advanced/negotiation-cordapp/repositories.gradle
+++ b/Advanced/negotiation-cordapp/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Advanced/obligation-cordapp/build.gradle
+++ b/Advanced/obligation-cordapp/build.gradle
@@ -50,7 +50,7 @@ allprojects {
         maven { url 'https://software.r3.com/artifactory/corda-lib' }
         maven { url 'https://software.r3.com/artifactory/corda-lib-dev' }
         maven { url 'https://jitpack.io' }
-        maven { url "https://repo.gradle.org/gradle/libs-releases-local" }
+        maven { url "https://repo.gradle.org/artifactory/libs-releases-local" }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/Advanced/obligation-cordapp/repositories.gradle
+++ b/Advanced/obligation-cordapp/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Advanced/secretsanta-cordapp/repositories.gradle
+++ b/Advanced/secretsanta-cordapp/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Advanced/snakesandladders-cordapp/build.gradle
+++ b/Advanced/snakesandladders-cordapp/build.gradle
@@ -54,7 +54,7 @@ allprojects { //Properties that you need to compile your project (The applicatio
         //SDK lib
         maven { url 'https://software.r3.com/artifactory/corda-lib' }
         //Gradle Plugins
-        maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+        maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/Advanced/snakesandladders-cordapp/repositories.gradle
+++ b/Advanced/snakesandladders-cordapp/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Basic/cordapp-example/.idea/jarRepositories.xml
+++ b/Basic/cordapp-example/.idea/jarRepositories.xml
@@ -14,7 +14,7 @@
     <remote-repository>
       <option name="id" value="maven3" />
       <option name="name" value="maven3" />
-      <option name="url" value="https://repo.gradle.org/gradle/libs-releases" />
+      <option name="url" value="https://repo.gradle.org/artifactory/libs-releases" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="MavenRepo" />

--- a/Basic/cordapp-example/repositories.gradle
+++ b/Basic/cordapp-example/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Basic/flow-database-access/workflows/build.gradle
+++ b/Basic/flow-database-access/workflows/build.gradle
@@ -14,7 +14,7 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/Basic/flow-http-access/repositories.gradle
+++ b/Basic/flow-http-access/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Basic/ping-pong/repositories.gradle
+++ b/Basic/ping-pong/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/BusinessNetworks/insurancebusinessnetwork/repositories.gradle
+++ b/BusinessNetworks/insurancebusinessnetwork/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/attachment-blacklist/build.gradle
+++ b/Features/attachment-blacklist/build.gradle
@@ -45,7 +45,7 @@ allprojects {
         mavenCentral()
         maven { url 'https://jitpack.io' }
         maven { url 'https://software.r3.com/artifactory/corda' }
-        maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+        maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/Features/attachment-blacklist/repositories.gradle
+++ b/Features/attachment-blacklist/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/attachment-sendfile/repositories.gradle
+++ b/Features/attachment-sendfile/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/confidentialIdentity-whistleblower/repositories.gradle
+++ b/Features/confidentialIdentity-whistleblower/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/contractsdk-recordplayers/repositories.gradle
+++ b/Features/contractsdk-recordplayers/repositories.gradle
@@ -4,6 +4,6 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
     maven { url 'https://software.r3.com/artifactory/corda-lib-dev' }
 }

--- a/Features/cordaService-autopayroll/repositories.gradle
+++ b/Features/cordaService-autopayroll/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/customlogging-yocordapp/repositories.gradle
+++ b/Features/customlogging-yocordapp/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/dockerform-yocordapp/repositories.gradle
+++ b/Features/dockerform-yocordapp/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/notarychange-iou/repositories.gradle
+++ b/Features/notarychange-iou/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/observableStates-tradereporting/repositories.gradle
+++ b/Features/observableStates-tradereporting/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/oracle-primenumber/repositories.gradle
+++ b/Features/oracle-primenumber/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/postgres-cordapp/repositories.gradle
+++ b/Features/postgres-cordapp/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/queryableState-carinsurance/repositories.gradle
+++ b/Features/queryableState-carinsurance/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/referenceStates-sanctionsBody/repositories.gradle
+++ b/Features/referenceStates-sanctionsBody/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Features/schedulableState-heartbeat/build.gradle
+++ b/Features/schedulableState-heartbeat/build.gradle
@@ -41,7 +41,7 @@ allprojects {
         mavenCentral()
         maven { url 'https://jitpack.io' }
         maven { url 'https://software.r3.com/artifactory/corda' }
-        maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+        maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/Features/schedulableState-heartbeat/repositories.gradle
+++ b/Features/schedulableState-heartbeat/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Tokens/bikemarket/repositories.gradle
+++ b/Tokens/bikemarket/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Tokens/dollartohousetoken/build.gradle
+++ b/Tokens/dollartohousetoken/build.gradle
@@ -51,7 +51,7 @@ allprojects {
         //SDK lib
         maven { url 'https://software.r3.com/artifactory/corda-lib' }
         //Gradle Plugins
-        maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+        maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 
     }
 

--- a/Tokens/dollartohousetoken/repositories.gradle
+++ b/Tokens/dollartohousetoken/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Tokens/fungiblehousetoken/build.gradle
+++ b/Tokens/fungiblehousetoken/build.gradle
@@ -49,7 +49,7 @@ allprojects {
         //SDK lib
         maven { url 'https://software.r3.com/artifactory/corda-lib' }
         //Gradle Plugins
-        maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+        maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/Tokens/fungiblehousetoken/repositories.gradle
+++ b/Tokens/fungiblehousetoken/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Tokens/stockpaydividend/build.gradle
+++ b/Tokens/stockpaydividend/build.gradle
@@ -53,7 +53,7 @@ allprojects {
         //SDK lib
         maven { url 'https://software.r3.com/artifactory/corda-lib' }
         //Gradle Plugins
-        maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+        maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/Tokens/stockpaydividend/repositories.gradle
+++ b/Tokens/stockpaydividend/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }

--- a/Tokens/tokentofriend/build.gradle
+++ b/Tokens/tokentofriend/build.gradle
@@ -52,7 +52,7 @@ allprojects { //Properties that you need to compile your project (The applicatio
         //SDK lib
         maven { url 'https://software.r3.com/artifactory/corda-lib' }
         //Gradle Plugins
-        maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+        maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 
     }
 

--- a/Tokens/tokentofriend/repositories.gradle
+++ b/Tokens/tokentofriend/repositories.gradle
@@ -4,5 +4,5 @@ repositories {
     jcenter()
     maven { url 'https://jitpack.io' }
     maven { url 'https://software.r3.com/artifactory/corda' }
-    maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://repo.gradle.org/artifactory/libs-releases' }
 }


### PR DESCRIPTION
`/gradle/` doesn't work anymore, but `/artifactory/` works.

The PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

-----
**Tested:** `./gradlew build` in several subdirs.

Before: 
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':node-driver:compileKotlin'.
> Could not resolve all files for configuration ':node-driver:compileClasspath'.
   > Could not find org.gradle:gradle-tooling-api:5.6.4.

```
After: No errors