### PR TITLE
ENT-6871: Code clean-up and formatting

### DIFF
--- a/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/contracts/AppleStampContract.kt
+++ b/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/contracts/AppleStampContract.kt
@@ -3,7 +3,6 @@ package com.tutorial.contracts
 import com.tutorial.states.AppleStamp
 import net.corda.core.contracts.CommandData
 import net.corda.core.contracts.Contract
-import net.corda.core.contracts.Requirements
 import net.corda.core.contracts.requireThat
 import net.corda.core.transactions.LedgerTransaction
 
@@ -23,10 +22,10 @@ class AppleStampContract : Contract {
                 "The output AppleStamp state should have clear description of the type of redeemable goods".using(output.stampDesc != "")
                 null
             }
-            is BasketOfApplesContract.Commands.Redeem-> requireThat {
+            is BasketOfApplesContract.Commands.Redeem -> requireThat {
                 //Transaction verification will happen in BasketOfApples Contract
             }
-    }
+        }
     }
 
     // Used to indicate the transaction's intent.

--- a/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/contracts/BasketOfApplesContract.kt
+++ b/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/contracts/BasketOfApplesContract.kt
@@ -24,7 +24,9 @@ class BasketOfApplesContract : Contract {
             is Commands.Redeem -> requireThat {
                 val input = tx.inputsOfType(AppleStamp::class.java)[0]
                 "This transaction should consume two states".using(tx.inputStates.size == 2)
-                "The issuer of the Apple stamp should be the producing farm of this basket of apple".using(input.issuer.equals(output.farm))
+                "The issuer of the Apple stamp should be the producing farm of this basket of apple".using(
+                    input.issuer.equals(output.farm)
+                )
                 "The basket of apple has to weight more than 0".using(output.weight > 0)
                 null
             }

--- a/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/contracts/TemplateContract.kt
+++ b/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/contracts/TemplateContract.kt
@@ -4,8 +4,9 @@ import com.tutorial.states.TemplateState
 import net.corda.core.contracts.CommandData
 import net.corda.core.contracts.Contract
 import net.corda.core.contracts.requireSingleCommand
-import net.corda.core.transactions.LedgerTransaction
 import net.corda.core.contracts.requireThat
+import net.corda.core.transactions.LedgerTransaction
+
 // ************
 // * Contract *
 // ************

--- a/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/states/AppleStamp.kt
+++ b/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/states/AppleStamp.kt
@@ -7,13 +7,12 @@ import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.serialization.ConstructorForDeserialization
-import java.util.ArrayList
 
 @BelongsToContract(AppleStampContract::class)
 class AppleStamp @ConstructorForDeserialization constructor(
-        val stampDesc : String,//For example: "One stamp can exchange for a basket of HoneyCrispy Apple"
-        val issuer: Party, //The person who issued the stamp
-        val holder: Party, //The person who currently owns the stamp
-        override val linearId: UniqueIdentifier,//LinearState required variable.
-        override val participants: List<AbstractParty> = listOf<AbstractParty>(issuer,holder)
-         ) : LinearState
+    val stampDesc: String,//For example: "One stamp can exchange for a basket of HoneyCrispy Apple"
+    val issuer: Party, //The person who issued the stamp
+    val holder: Party, //The person who currently owns the stamp
+    override val linearId: UniqueIdentifier,//LinearState required variable.
+    override val participants: List<AbstractParty> = listOf<AbstractParty>(issuer, holder)
+) : LinearState

--- a/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/states/BasketOfApples.kt
+++ b/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/states/BasketOfApples.kt
@@ -7,21 +7,22 @@ import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 
 @BelongsToContract(BasketOfApplesContract::class)
-class BasketOfApples(var description : String, //Brand or type
-                    var farm : Party, //Origin of the apple
-                    var owner: Party, //The person who exchange the basket of apple with the stamp.
-                    var weight: Int)
-    : ContractState {
+class BasketOfApples(
+    var description: String, //Brand or type
+    var farm: Party, //Origin of the apple
+    var owner: Party, //The person who exchange the basket of apple with the stamp.
+    var weight: Int
+) : ContractState {
 
     //Secondary Constructor
     constructor(description: String, farm: Party, weight: Int) : this(
-            description = description,
-            farm = farm,
-            owner = farm,
-            weight = weight
+        description = description,
+        farm = farm,
+        owner = farm,
+        weight = weight
     )
 
-    override var participants: List<AbstractParty> = listOf<AbstractParty>(farm,owner)
+    override var participants: List<AbstractParty> = listOf<AbstractParty>(farm, owner)
 
     fun changeOwner(buyer: Party): BasketOfApples {
         return BasketOfApples(description, farm, buyer, weight)

--- a/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/states/TemplateState.kt
+++ b/Basic/tutorial-applestamp/contracts/src/main/kotlin/com/tutorial/states/TemplateState.kt
@@ -10,8 +10,9 @@ import net.corda.core.identity.Party
 // * State *
 // *********
 @BelongsToContract(TemplateContract::class)
-data class TemplateState(val msg: String,
-                         val sender: Party,
-                         val receiver: Party,
-                         override val participants: List<AbstractParty> = listOf(sender,receiver)
+data class TemplateState(
+    val msg: String,
+    val sender: Party,
+    val receiver: Party,
+    override val participants: List<AbstractParty> = listOf(sender, receiver)
 ) : ContractState

--- a/Basic/tutorial-applestamp/contracts/src/test/kotlin/com/tutorial/contracts/ContractTests.kt
+++ b/Basic/tutorial-applestamp/contracts/src/test/kotlin/com/tutorial/contracts/ContractTests.kt
@@ -1,14 +1,13 @@
 package com.tutorial.contracts
 
 import com.tutorial.states.AppleStamp
+import com.tutorial.states.TemplateState
+import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.identity.CordaX500Name
 import net.corda.testing.core.TestIdentity
 import net.corda.testing.node.MockServices
 import net.corda.testing.node.ledger
 import org.junit.Test
-import com.tutorial.states.TemplateState
-import net.corda.core.contracts.UniqueIdentifier
-import java.security.PublicKey
 import java.util.*
 
 class ContractTests {
@@ -39,7 +38,7 @@ class ContractTests {
     }
 
     @Test
-    fun stampIssuanceCanOnlyHaveOneOutput(){
+    fun stampIssuanceCanOnlyHaveOneOutput() {
         val stamp = AppleStamp("FUji4072", alice.party, bob.party, UniqueIdentifier())
         val stamp2 = AppleStamp("HoneyCrispy7864", alice.party, bob.party, UniqueIdentifier())
 
@@ -63,7 +62,7 @@ class ContractTests {
     }
 
     @Test
-    fun StampMustHaveDescription(){
+    fun StampMustHaveDescription() {
         val stamp = AppleStamp("", alice.party, bob.party, UniqueIdentifier())
         val stamp2 = AppleStamp("FUji4072", alice.party, bob.party, UniqueIdentifier())
 
@@ -84,9 +83,6 @@ class ContractTests {
             }
         }
     }
-
-
-
 
 
 }

--- a/Basic/tutorial-applestamp/contracts/src/test/kotlin/com/tutorial/contracts/StateTests.kt
+++ b/Basic/tutorial-applestamp/contracts/src/test/kotlin/com/tutorial/contracts/StateTests.kt
@@ -16,7 +16,7 @@ class StateTests {
     }
 
     @Test
-    fun AppleStampStateHasFieldOfCorrectType(){
+    fun AppleStampStateHasFieldOfCorrectType() {
         AppleStamp::class.java.getDeclaredField("stampDesc")
         assert(AppleStamp::class.java.getDeclaredField("stampDesc").type == String::class.java)
 

--- a/Basic/tutorial-applestamp/workflows/src/main/kotlin/com/tutorial/flows/CreateAndIssueAppleStamp.kt
+++ b/Basic/tutorial-applestamp/workflows/src/main/kotlin/com/tutorial/flows/CreateAndIssueAppleStamp.kt
@@ -13,7 +13,8 @@ import java.util.*
 
 @InitiatingFlow
 @StartableByRPC
-class CreateAndIssueAppleStampInitiator(private val stampDescription: String, private val holder: Party) : FlowLogic<SignedTransaction>(){
+class CreateAndIssueAppleStampInitiator(private val stampDescription: String, private val holder: Party) :
+    FlowLogic<SignedTransaction>() {
 
     @Suspendable
     override fun call(): SignedTransaction {
@@ -32,9 +33,11 @@ class CreateAndIssueAppleStampInitiator(private val stampDescription: String, pr
 
         //Compositing the transaction
         val txBuilder = TransactionBuilder(notary)
-                .addOutputState(newStamp)
-                .addCommand(AppleStampContract.Commands.Issue(),
-                        listOf(ourIdentity.owningKey, holder.owningKey))
+            .addOutputState(newStamp)
+            .addCommand(
+                AppleStampContract.Commands.Issue(),
+                listOf(ourIdentity.owningKey, holder.owningKey)
+            )
 
         // Verify that the transaction is valid.
         txBuilder.verify(serviceHub)
@@ -47,7 +50,8 @@ class CreateAndIssueAppleStampInitiator(private val stampDescription: String, pr
         // Send the state to the counterparty, and receive it back with their signature.
         val otherPartySession = initiateFlow(holder)
         val fullySignedTx = subFlow(
-                CollectSignaturesFlow(partSignedTx, Arrays.asList(otherPartySession)))
+            CollectSignaturesFlow(partSignedTx, Arrays.asList(otherPartySession))
+        )
 
         // Notarise and record the transaction in both parties' vaults.
         return subFlow(FinalityFlow(fullySignedTx, Arrays.asList(otherPartySession)))

--- a/Basic/tutorial-applestamp/workflows/src/main/kotlin/com/tutorial/flows/Flows.kt
+++ b/Basic/tutorial-applestamp/workflows/src/main/kotlin/com/tutorial/flows/Flows.kt
@@ -1,27 +1,16 @@
 package com.tutorial.flows
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.flows.*
-import net.corda.core.utilities.ProgressTracker
-import net.corda.core.flows.FinalityFlow
-
-import net.corda.core.flows.CollectSignaturesFlow
-
-import net.corda.core.transactions.SignedTransaction
-
-import java.util.stream.Collectors
-
-import net.corda.core.flows.FlowSession
-
-import net.corda.core.identity.Party
-
 import com.tutorial.contracts.TemplateContract
-
-import net.corda.core.transactions.TransactionBuilder
-
 import com.tutorial.states.TemplateState
 import net.corda.core.contracts.requireThat
+import net.corda.core.flows.*
 import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.ProgressTracker
+import java.util.stream.Collectors
 
 
 // *********
@@ -47,8 +36,8 @@ class Initiator(private val receiver: Party) : FlowLogic<SignedTransaction>() {
 
         // Step 3. Create a new TransactionBuilder object.
         val builder = TransactionBuilder(notary)
-                .addCommand(TemplateContract.Commands.Create(), listOf(sender.owningKey, receiver.owningKey))
-                .addOutputState(output)
+            .addCommand(TemplateContract.Commands.Create(), listOf(sender.owningKey, receiver.owningKey))
+            .addOutputState(output)
 
         // Step 4. Verify and sign it with our KeyPair.
         builder.verify(serviceHub)
@@ -56,7 +45,8 @@ class Initiator(private val receiver: Party) : FlowLogic<SignedTransaction>() {
 
 
         // Step 6. Collect the other party's signature using the SignTransactionFlow.
-        val otherParties: MutableList<Party> = output.participants.stream().map { el: AbstractParty? -> el as Party? }.collect(Collectors.toList())
+        val otherParties: MutableList<Party> =
+            output.participants.stream().map { el: AbstractParty? -> el as Party? }.collect(Collectors.toList())
         otherParties.remove(ourIdentity)
         val sessions = otherParties.stream().map { el: Party? -> initiateFlow(el!!) }.collect(Collectors.toList())
 
@@ -73,7 +63,7 @@ class Responder(val counterpartySession: FlowSession) : FlowLogic<SignedTransact
     override fun call(): SignedTransaction {
         val signTransactionFlow = object : SignTransactionFlow(counterpartySession) {
             override fun checkTransaction(stx: SignedTransaction) = requireThat {
-               //Addition checks
+                //Addition checks
             }
         }
         val txId = subFlow(signTransactionFlow).id

--- a/Basic/tutorial-applestamp/workflows/src/main/kotlin/com/tutorial/flows/PackageApples.kt
+++ b/Basic/tutorial-applestamp/workflows/src/main/kotlin/com/tutorial/flows/PackageApples.kt
@@ -3,14 +3,17 @@ package com.tutorial.flows
 import co.paralleluniverse.fibers.Suspendable
 import com.tutorial.contracts.BasketOfApplesContract.Commands.packBasket
 import com.tutorial.states.BasketOfApples
-import net.corda.core.flows.*
-import net.corda.core.identity.Party
+import net.corda.core.flows.FinalityFlow
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
 
 @InitiatingFlow
 @StartableByRPC
-class PackApplesInitiator(private val appleDescription: String, private val weight: Int) : FlowLogic<SignedTransaction>(){
+class PackApplesInitiator(private val appleDescription: String, private val weight: Int) :
+    FlowLogic<SignedTransaction>() {
 
     @Suspendable
     override fun call(): SignedTransaction {
@@ -28,8 +31,8 @@ class PackApplesInitiator(private val appleDescription: String, private val weig
 
         //Building transaction
         val txBuilder = TransactionBuilder(notary)
-                .addOutputState(basket)
-                .addCommand(packBasket(), ourIdentity.owningKey)
+            .addOutputState(basket)
+            .addCommand(packBasket(), ourIdentity.owningKey)
 
         // Verify the transaction
         txBuilder.verify(serviceHub)

--- a/Basic/tutorial-applestamp/workflows/src/test/kotlin/com/tutorial/CreateAndIssueAppleStampTest.kt
+++ b/Basic/tutorial-applestamp/workflows/src/test/kotlin/com/tutorial/CreateAndIssueAppleStampTest.kt
@@ -25,9 +25,14 @@ class CreateAndIssueAppleStampTest {
 
     @Before
     fun setup() {
-        network = MockNetwork(MockNetworkParameters().withCordappsForAllNodes(ImmutableList.of(
-                TestCordapp.findCordapp("com.tutorial.contracts"),
-                TestCordapp.findCordapp("com.tutorial.flows"))))
+        network = MockNetwork(
+            MockNetworkParameters().withCordappsForAllNodes(
+                ImmutableList.of(
+                    TestCordapp.findCordapp("com.tutorial.contracts"),
+                    TestCordapp.findCordapp("com.tutorial.flows")
+                )
+            )
+        )
         a = network!!.createPartyNode(null)
         b = network!!.createPartyNode(null)
         network!!.runNetwork()
@@ -47,21 +52,22 @@ class CreateAndIssueAppleStampTest {
         //successful query means the state is stored at node b's vault. Flow went through.
         val inputCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria().withStatus(StateStatus.UNCONSUMED)
         val state = b!!.services.vaultService
-                .queryBy(TemplateState::class.java, inputCriteria).states[0].state.data
+            .queryBy(TemplateState::class.java, inputCriteria).states[0].state.data
     }
 
     @Test
     fun CreateAndIssueAppleStampTest() {
         val flow1 = CreateAndIssueAppleStampInitiator(
-                "HoneyCrispy 4072", b!!.info.legalIdentities[0])
+            "HoneyCrispy 4072", b!!.info.legalIdentities[0]
+        )
         val future1: Future<SignedTransaction> = a!!.startFlow(flow1)
         network!!.runNetwork()
 
         //successful query means the state is stored at node b's vault. Flow went through.
         val inputCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria()
-                .withStatus(StateStatus.UNCONSUMED)
+            .withStatus(StateStatus.UNCONSUMED)
         val state = b!!.services.vaultService
-                .queryBy(AppleStamp::class.java, inputCriteria).states[0].state.data
+            .queryBy(AppleStamp::class.java, inputCriteria).states[0].state.data
         assert(state.stampDesc == "HoneyCrispy 4072")
     }
 }

--- a/Basic/tutorial-applestamp/workflows/src/test/kotlin/com/tutorial/FarmerSelfCreateBasketOfApplesTest.kt
+++ b/Basic/tutorial-applestamp/workflows/src/test/kotlin/com/tutorial/FarmerSelfCreateBasketOfApplesTest.kt
@@ -19,11 +19,17 @@ class FarmerSelfCreateBasketOfApplesTest {
     private var network: MockNetwork? = null
     private var a: StartedMockNode? = null
     private var b: StartedMockNode? = null
+
     @Before
     fun setup() {
-        network = MockNetwork(MockNetworkParameters().withCordappsForAllNodes(ImmutableList.of(
-                TestCordapp.findCordapp("com.tutorial.contracts"),
-                TestCordapp.findCordapp("com.tutorial.flows"))))
+        network = MockNetwork(
+            MockNetworkParameters().withCordappsForAllNodes(
+                ImmutableList.of(
+                    TestCordapp.findCordapp("com.tutorial.contracts"),
+                    TestCordapp.findCordapp("com.tutorial.flows")
+                )
+            )
+        )
         a = network!!.createPartyNode(null)
         b = network!!.createPartyNode(null)
         network!!.runNetwork()
@@ -43,7 +49,7 @@ class FarmerSelfCreateBasketOfApplesTest {
         //successful query means the state is stored at node b's vault. Flow went through.
         val inputCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria().withStatus(StateStatus.UNCONSUMED)
         val state = a!!.services.vaultService
-                .queryBy(BasketOfApples::class.java, inputCriteria).states[0].state.data
+            .queryBy(BasketOfApples::class.java, inputCriteria).states[0].state.data
         println("-------------------------")
         println(state.owner)
         println("-------------------------")

--- a/Basic/tutorial-applestamp/workflows/src/test/kotlin/com/tutorial/FlowTests.kt
+++ b/Basic/tutorial-applestamp/workflows/src/test/kotlin/com/tutorial/FlowTests.kt
@@ -1,15 +1,18 @@
 package com.tutorial
 
-import net.corda.testing.node.*
+import com.tutorial.flows.Initiator
+import com.tutorial.states.TemplateState
+import net.corda.core.node.services.Vault.StateStatus
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.transactions.SignedTransaction
+import net.corda.testing.node.MockNetwork
+import net.corda.testing.node.MockNetworkParameters
+import net.corda.testing.node.StartedMockNode
+import net.corda.testing.node.TestCordapp
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import com.tutorial.states.TemplateState
-import java.util.concurrent.Future;
-import net.corda.core.node.services.vault.QueryCriteria
-import net.corda.core.transactions.SignedTransaction
-import com.tutorial.flows.Initiator
-import net.corda.core.node.services.Vault.StateStatus
+import java.util.concurrent.Future
 
 
 class FlowTests {
@@ -19,10 +22,14 @@ class FlowTests {
 
     @Before
     fun setup() {
-        network = MockNetwork(MockNetworkParameters(cordappsForAllNodes = listOf(
-                TestCordapp.findCordapp("com.tutorial.contracts"),
-                TestCordapp.findCordapp("com.tutorial.flows")
-        )))
+        network = MockNetwork(
+            MockNetworkParameters(
+                cordappsForAllNodes = listOf(
+                    TestCordapp.findCordapp("com.tutorial.contracts"),
+                    TestCordapp.findCordapp("com.tutorial.flows")
+                )
+            )
+        )
         a = network.createPartyNode()
         b = network.createPartyNode()
         network.runNetwork()
@@ -32,6 +39,7 @@ class FlowTests {
     fun tearDown() {
         network.stopNodes()
     }
+
     @Test
     fun `DummyTest`() {
         val flow = Initiator(b.info.legalIdentities[0])

--- a/Basic/tutorial-applestamp/workflows/src/test/kotlin/com/tutorial/RedeemApplesWithStampTest.kt
+++ b/Basic/tutorial-applestamp/workflows/src/test/kotlin/com/tutorial/RedeemApplesWithStampTest.kt
@@ -6,7 +6,6 @@ import com.tutorial.flows.PackApplesInitiator
 import com.tutorial.flows.RedeemApplesInitiator
 import com.tutorial.states.AppleStamp
 import com.tutorial.states.BasketOfApples
-import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.node.services.Vault.StateStatus
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.SignedTransaction
@@ -24,11 +23,17 @@ class RedeemApplesWithStampTest {
     private var network: MockNetwork? = null
     private var a: StartedMockNode? = null
     private var b: StartedMockNode? = null
+
     @Before
     fun setup() {
-        network = MockNetwork(MockNetworkParameters().withCordappsForAllNodes(ImmutableList.of(
-                TestCordapp.findCordapp("com.tutorial.contracts"),
-                TestCordapp.findCordapp("com.tutorial.flows"))))
+        network = MockNetwork(
+            MockNetworkParameters().withCordappsForAllNodes(
+                ImmutableList.of(
+                    TestCordapp.findCordapp("com.tutorial.contracts"),
+                    TestCordapp.findCordapp("com.tutorial.flows")
+                )
+            )
+        )
         a = network!!.createPartyNode(null)
         b = network!!.createPartyNode(null)
         network!!.runNetwork()
@@ -49,7 +54,8 @@ class RedeemApplesWithStampTest {
 
         //Issue Apple Stamp
         val issueAppleStamp = CreateAndIssueAppleStampInitiator(
-                "Fuji4072", b!!.info.legalIdentities[0])
+            "Fuji4072", b!!.info.legalIdentities[0]
+        )
         val future1: Future<SignedTransaction> = a!!.startFlow(issueAppleStamp)
         network!!.runNetwork()
         val issuedStamp = future1.get().tx.outputStates[0] as AppleStamp
@@ -63,7 +69,7 @@ class RedeemApplesWithStampTest {
         //successful query means the state is stored at node b's vault. Flow went through.
         val outputCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria().withStatus(StateStatus.UNCONSUMED)
         val state = b!!.services.vaultService
-                .queryBy(BasketOfApples::class.java, outputCriteria).states[0].state.data
+            .queryBy(BasketOfApples::class.java, outputCriteria).states[0].state.data
         assert(state.description == "Fuji4072")
     }
 }


### PR DESCRIPTION
### Overview / Changes
Removed unused imports and applied formatting to `tutorial-applestamp` Kotlin sample. 

Note: Intellij auto-formatting feature (both for imports and logic) is used. Though it doesn't always provide the best formatting, in most cases it gives a better and consistent formatting. 

### Test 
No logic change. Ran `gradlew build` and verified it succeeded.