### PR TITLE
ENT-11793: Fix integration tests in JDK17 CorDapps

### DIFF
--- a/Accounts/obligation-accounts/build.gradle
+++ b/Accounts/obligation-accounts/build.gradle
@@ -61,6 +61,10 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Accounts/obligation-accounts/workflows/build.gradle
+++ b/Accounts/obligation-accounts/workflows/build.gradle
@@ -36,8 +36,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOnly
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Accounts/sharestatewithaccount/build.gradle
+++ b/Accounts/sharestatewithaccount/build.gradle
@@ -51,6 +51,10 @@ buildscript {
 allprojects {
     apply plugin: 'org.jetbrains.kotlin.jvm'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Accounts/sharestatewithaccount/workflows/build.gradle
+++ b/Accounts/sharestatewithaccount/workflows/build.gradle
@@ -37,8 +37,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Accounts/supplychain/build.gradle
+++ b/Accounts/supplychain/build.gradle
@@ -50,6 +50,10 @@ buildscript {
 allprojects {
     apply plugin: 'org.jetbrains.kotlin.jvm'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Accounts/supplychain/workflows/build.gradle
+++ b/Accounts/supplychain/workflows/build.gradle
@@ -37,8 +37,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Accounts/tictacthor/build.gradle
+++ b/Accounts/tictacthor/build.gradle
@@ -56,6 +56,10 @@ buildscript {
 allprojects {
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Accounts/tictacthor/workflows/build.gradle
+++ b/Accounts/tictacthor/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Advanced/auction-cordapp/workflows/build.gradle
+++ b/Advanced/auction-cordapp/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 

--- a/Advanced/duediligence-cordapp/build.gradle
+++ b/Advanced/duediligence-cordapp/build.gradle
@@ -52,6 +52,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'org.jetbrains.kotlin.jvm'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Advanced/duediligence-cordapp/workflows/build.gradle
+++ b/Advanced/duediligence-cordapp/workflows/build.gradle
@@ -34,8 +34,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -47,6 +47,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     corda "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Advanced/obligation-cordapp/build.gradle
+++ b/Advanced/obligation-cordapp/build.gradle
@@ -72,6 +72,10 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'org.jetbrains.kotlin.jvm'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Advanced/obligation-cordapp/workflows/build.gradle
+++ b/Advanced/obligation-cordapp/workflows/build.gradle
@@ -34,8 +34,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOnly
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Advanced/secretsanta-cordapp/build.gradle
+++ b/Advanced/secretsanta-cordapp/build.gradle
@@ -50,6 +50,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Advanced/secretsanta-cordapp/contracts/build.gradle
+++ b/Advanced/secretsanta-cordapp/contracts/build.gradle
@@ -12,8 +12,8 @@ cordapp {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOnly
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Advanced/secretsanta-cordapp/workflows/build.gradle
+++ b/Advanced/secretsanta-cordapp/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOnly
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Advanced/snakesandladders-cordapp/build.gradle
+++ b/Advanced/snakesandladders-cordapp/build.gradle
@@ -55,6 +55,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Advanced/snakesandladders-cordapp/workflows/build.gradle
+++ b/Advanced/snakesandladders-cordapp/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Advanced/superyacht-cordapp/build.gradle
+++ b/Advanced/superyacht-cordapp/build.gradle
@@ -52,6 +52,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'org.jetbrains.kotlin.jvm'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/Advanced/superyacht-cordapp/workflows/build.gradle
+++ b/Advanced/superyacht-cordapp/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOnly
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Advanced/syndicated-lending/build.gradle
+++ b/Advanced/syndicated-lending/build.gradle
@@ -23,7 +23,7 @@ buildscript { //properties that you need to build the project
         spring_boot_version = '3.2.5'
         spring_boot_gradle_plugin_version = '3.2.5'
 
-        test_add_opens = ['--add-opens', 'java.base/java.time=ALL-UNNAMED', '--add-opens', 'java.base/java.io=ALL-UNNAMED',
+        testJvmArgs = ['--add-opens', 'java.base/java.time=ALL-UNNAMED', '--add-opens', 'java.base/java.io=ALL-UNNAMED',
                           '--add-opens', 'java.base/java.util=ALL-UNNAMED', '--add-opens', 'java.base/java.net=ALL-UNNAMED',
                           '--add-opens', 'java.base/java.nio=ALL-UNNAMED', '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',
                           '--add-opens', 'java.base/java.security.cert=ALL-UNNAMED', '--add-opens', 'java.base/java.security=ALL-UNNAMED',
@@ -49,6 +49,10 @@ buildscript { //properties that you need to build the project
 allprojects { //Properties that you need to compile your project (The application)
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
+
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
 
     repositories {
         mavenLocal()

--- a/Advanced/syndicated-lending/contracts/build.gradle
+++ b/Advanced/syndicated-lending/contracts/build.gradle
@@ -24,5 +24,5 @@ dependencies {
 }
 
 test {
-    jvmArgs = rootProject.ext.test_add_opens
+    jvmArgs = rootProject.ext.testJvmArgs
 }

--- a/Advanced/syndicated-lending/workflows/build.gradle
+++ b/Advanced/syndicated-lending/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -59,5 +59,5 @@ task integrationTest(type: Test, dependsOn: []) {
 }
 
 test {
-    jvmArgs = rootProject.ext.test_add_opens
+    jvmArgs = rootProject.ext.testJvmArgs
 }

--- a/Basic/opentelemetry-cordapp-example/workflows/build.gradle
+++ b/Basic/opentelemetry-cordapp-example/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Basic/ping-pong/workflows/build.gradle
+++ b/Basic/ping-pong/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOnly
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Basic/tutorial-applestamp/build.gradle
+++ b/Basic/tutorial-applestamp/build.gradle
@@ -51,6 +51,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/../repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         compilerOptions {
             languageVersion = KOTLIN_1_9

--- a/Basic/tutorial-applestamp/workflows/build.gradle
+++ b/Basic/tutorial-applestamp/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -47,6 +47,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Basic/tutorial-jarsigning/build.gradle
+++ b/Basic/tutorial-jarsigning/build.gradle
@@ -49,6 +49,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/../repositories.gradle"
     apply plugin: 'org.jetbrains.kotlin.jvm'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         compilerOptions {
             languageVersion = KOTLIN_1_9

--- a/Basic/tutorial-jarsigning/workflows/build.gradle
+++ b/Basic/tutorial-jarsigning/workflows/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/attachment-blacklist/build.gradle
+++ b/Features/attachment-blacklist/build.gradle
@@ -49,6 +49,10 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Features/attachment-blacklist/workflows/build.gradle
+++ b/Features/attachment-blacklist/workflows/build.gradle
@@ -34,8 +34,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -47,6 +47,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/attachment-sendfile/build.gradle
+++ b/Features/attachment-sendfile/build.gradle
@@ -46,6 +46,11 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
+
     repositories {
         mavenLocal()
 

--- a/Features/attachment-sendfile/workflows/build.gradle
+++ b/Features/attachment-sendfile/workflows/build.gradle
@@ -36,8 +36,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -49,6 +49,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/confidentialIdentity-whistleblower/build.gradle
+++ b/Features/confidentialIdentity-whistleblower/build.gradle
@@ -50,6 +50,10 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Features/confidentialIdentity-whistleblower/workflows/build.gradle
+++ b/Features/confidentialIdentity-whistleblower/workflows/build.gradle
@@ -37,8 +37,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -55,6 +55,8 @@ dependencies {
     cordaProvided "$corda_release_group:corda:$corda_release_version"
 
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
+
     cordaProvided "org.apache.logging.log4j:log4j-slf4j2-impl:$log4j_version"
 
     cordapp "$corda_release_group:corda-confidential-identities:$corda_release_version"

--- a/Features/contractsdk-recordplayers/build.gradle
+++ b/Features/contractsdk-recordplayers/build.gradle
@@ -51,6 +51,10 @@ allprojects { // Properties that you need to compile your project (The applicati
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Features/contractsdk-recordplayers/contracts/build.gradle
+++ b/Features/contractsdk-recordplayers/contracts/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testImplementation "junit:junit:$junit_version"
 
-    implementation "com.r3.corda.lib.contracts:contract-sdk:0.9-SNAPSHOT"
+    implementation "com.r3.corda.lib.contracts:contract-sdk:1.0-SNAPSHOT"
 
     // Corda dependencies.
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
@@ -53,4 +53,8 @@ dependencies {
 
 test {
     jvmArgs = rootProject.ext.testJvmArgs
+}
+
+tasks.jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/Features/contractsdk-recordplayers/workflows/build.gradle
+++ b/Features/contractsdk-recordplayers/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -47,8 +47,9 @@ dependencies {
     // Corda dependencies.
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
-    cordaProvided "com.r3.corda.lib.contracts:contract-sdk:0.9-SNAPSHOT"
+    cordaProvided "com.r3.corda.lib.contracts:contract-sdk:1.0-SNAPSHOT"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/cordaService-autopayroll/build.gradle
+++ b/Features/cordaService-autopayroll/build.gradle
@@ -50,6 +50,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Features/cordaService-autopayroll/workflows/build.gradle
+++ b/Features/cordaService-autopayroll/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/customlogging-yocordapp/build.gradle
+++ b/Features/customlogging-yocordapp/build.gradle
@@ -50,6 +50,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Features/customlogging-yocordapp/workflows/build.gradle
+++ b/Features/customlogging-yocordapp/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -48,6 +48,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/customquery-carinsurance/build.gradle
+++ b/Features/customquery-carinsurance/build.gradle
@@ -51,6 +51,10 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
         jcenter()

--- a/Features/customquery-carinsurance/workflows/build.gradle
+++ b/Features/customquery-carinsurance/workflows/build.gradle
@@ -35,8 +35,8 @@ sourceSets {
 
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -48,6 +48,7 @@ dependencies {
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     cordaProvided "$corda_release_group:corda-testserver-impl:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/dockerform-yocordapp/build.gradle
+++ b/Features/dockerform-yocordapp/build.gradle
@@ -50,6 +50,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Features/dockerform-yocordapp/workflows/build.gradle
+++ b/Features/dockerform-yocordapp/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/encumbrance-avatar/build.gradle
+++ b/Features/encumbrance-avatar/build.gradle
@@ -49,6 +49,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/Features/encumbrance-avatar/workflows/build.gradle
+++ b/Features/encumbrance-avatar/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/notarychange-iou/build.gradle
+++ b/Features/notarychange-iou/build.gradle
@@ -46,6 +46,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Features/notarychange-iou/workflows/build.gradle
+++ b/Features/notarychange-iou/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/observableStates-tradereporting/build.gradle
+++ b/Features/observableStates-tradereporting/build.gradle
@@ -50,6 +50,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Features/observableStates-tradereporting/workflows/build.gradle
+++ b/Features/observableStates-tradereporting/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/postgres-cordapp/build.gradle
+++ b/Features/postgres-cordapp/build.gradle
@@ -50,6 +50,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Features/postgres-cordapp/workflows/build.gradle
+++ b/Features/postgres-cordapp/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/queryableState-carinsurance/build.gradle
+++ b/Features/queryableState-carinsurance/build.gradle
@@ -51,6 +51,10 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
         jcenter()

--- a/Features/queryableState-carinsurance/workflows/build.gradle
+++ b/Features/queryableState-carinsurance/workflows/build.gradle
@@ -35,8 +35,9 @@ sourceSets {
 
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
+
 }
 
 dependencies {
@@ -48,6 +49,7 @@ dependencies {
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     cordaProvided "$corda_release_group:corda-testserver-impl:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Features/referenceStates-sanctionsBody/workflows/build.gradle
+++ b/Features/referenceStates-sanctionsBody/workflows/build.gradle
@@ -37,8 +37,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOnly
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Features/state-reissuance/build.gradle
+++ b/Features/state-reissuance/build.gradle
@@ -57,6 +57,10 @@ allprojects { //Properties that you need to compile your project (The applicatio
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
         mavenCentral()

--- a/Features/state-reissuance/workflows/build.gradle
+++ b/Features/state-reissuance/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Tokens/bikemarket/build.gradle
+++ b/Tokens/bikemarket/build.gradle
@@ -54,6 +54,10 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Tokens/bikemarket/workflows/build.gradle
+++ b/Tokens/bikemarket/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -48,6 +48,7 @@ dependencies {
     cordaProvided "$corda_release_group:corda:$corda_release_version"
 
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Tokens/dollartohousetoken/build.gradle
+++ b/Tokens/dollartohousetoken/build.gradle
@@ -49,6 +49,10 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Tokens/dollartohousetoken/workflows/build.gradle
+++ b/Tokens/dollartohousetoken/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Tokens/fungiblehousetoken/build.gradle
+++ b/Tokens/fungiblehousetoken/build.gradle
@@ -50,6 +50,10 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Tokens/fungiblehousetoken/workflows/build.gradle
+++ b/Tokens/fungiblehousetoken/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Tokens/stockpaydividend/build.gradle
+++ b/Tokens/stockpaydividend/build.gradle
@@ -51,6 +51,10 @@ allprojects {
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
 
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
+
     repositories {
         mavenLocal()
 

--- a/Tokens/stockpaydividend/workflows/build.gradle
+++ b/Tokens/stockpaydividend/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {

--- a/Tokens/tokentofriend/build.gradle
+++ b/Tokens/tokentofriend/build.gradle
@@ -24,6 +24,13 @@ buildscript { //properties that you need to build the project
         //Token
         tokens_release_group = 'com.r3.corda.lib.tokens'
         tokens_release_version = '1.3-RC02'
+
+        testJvmArgs = ['--add-opens', 'java.base/java.time=ALL-UNNAMED', '--add-opens', 'java.base/java.io=ALL-UNNAMED',
+                       '--add-opens', 'java.base/java.util=ALL-UNNAMED', '--add-opens', 'java.base/java.net=ALL-UNNAMED',
+                       '--add-opens', 'java.base/java.nio=ALL-UNNAMED', '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',
+                       '--add-opens', 'java.base/java.security.cert=ALL-UNNAMED', '--add-opens', 'java.base/java.security=ALL-UNNAMED',
+                       '--add-opens', 'java.base/javax.net.ssl=ALL-UNNAMED', '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+                       '--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED', '--add-opens', 'java.sql/java.sql=ALL-UNNAMED',]
     }
 
     repositories {
@@ -45,6 +52,10 @@ buildscript { //properties that you need to build the project
 allprojects { //Properties that you need to compile your project (The application)
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'
+
+    tasks.withType(Test) {
+        jvmArgs = rootProject.ext.testJvmArgs
+    }
 
     repositories {
         mavenLocal()

--- a/Tokens/tokentofriend/workflows/build.gradle
+++ b/Tokens/tokentofriend/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")


### PR DESCRIPTION
Integration tests were missed in previous PRs and were not verified.
For integration tests to work correctly the following changes were needed:
- Gradle syntax update: `integrationTestCompile` and `integrationTestRuntime` updated to `integrationTestImplementation` and `integrationTestRuntimeOnly` so the integration tests can use tests' dependencies, as per [Gradle docs](https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal)
- add missing dependencies for integration tests
- add add-opens JVM args to integration tests where necessary