### PR TITLE
ENT-11803 - Account/obligation-accounts

### DIFF
--- a/Accounts/obligation-accounts/build.gradle
+++ b/Accounts/obligation-accounts/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     // Corda dependencies.
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
-    cordaProvided "$corda_release_group:corda-finance-workflows:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-workflows:$corda_release_version"
 
     cordaBootstrapper ("$corda_release_group:corda-node-api:$corda_release_version") {
         exclude group: "ch.qos.logback", module: "logback-classic"
@@ -134,7 +134,7 @@ dependencies {
     cordapp project(":contracts")
 
     cordapp "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
-    cordapp "$corda_release_group:corda-finance-workflows:$corda_release_version"
+    cordapp "$corda_core_release_group:corda-finance-workflows:$corda_release_version"
     cordapp "$corda_release_group:corda-confidential-identities:$corda_release_version"
 
 
@@ -166,7 +166,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapp project(':contracts')
         cordapp project(':workflows')
         cordapp("$corda_core_release_group:corda-finance-contracts:$corda_release_version")
-        cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
+        cordapp("$corda_core_release_group:corda-finance-workflows:$corda_release_version")
         cordapp("$corda_release_group:corda-confidential-identities:$corda_release_version")
         rpcUsers = [[ user: "user1", "password": "password", "permissions": ["ALL"]]]
         runSchemaMigration = true

--- a/Accounts/obligation-accounts/build.gradle
+++ b/Accounts/obligation-accounts/build.gradle
@@ -48,8 +48,6 @@ buildscript {
         //
         // Specify your own repos here, including any authentication details that are required.
         //
-
-        maven { url 'https://download.corda.net/maven/corda-releases' }
     }
 
     dependencies {

--- a/Accounts/obligation-accounts/build.gradle
+++ b/Accounts/obligation-accounts/build.gradle
@@ -41,28 +41,13 @@ buildscript {
 
     }
 
-ext.artifactory_contextUrl = 'https://software.r3.com/artifactory'
-ext.cordaArtifactoryUsername = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: ''
-ext.cordaArtifactoryPassword = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: ''
-
-
     repositories {
         mavenLocal()
         mavenCentral()
 
-        maven {
-            url "https://software.r3.com/artifactory/r3-corda-releases"
-            authentication {
-                basic(BasicAuthentication)
-            }
-            credentials {
-                username = cordaArtifactoryUsername
-                password = cordaArtifactoryPassword
-            }
-            mavenContent {
-                releasesOnly()
-            }
-        }
+        //
+        // Specify your own repos here, including any authentication details that are required.
+        //
 
         maven { url 'https://download.corda.net/maven/corda-releases' }
     }
@@ -135,7 +120,7 @@ sourceSets {
 dependencies {
     // Corda dependencies.
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_release_group:corda-finance-workflows:$corda_release_version"
 
     cordaBootstrapper ("$corda_release_group:corda-node-api:$corda_release_version") {
@@ -148,7 +133,7 @@ dependencies {
     cordapp project(":workflows")
     cordapp project(":contracts")
 
-    cordapp "net.corda:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_release_group:corda-finance-workflows:$corda_release_version"
     cordapp "$corda_release_group:corda-confidential-identities:$corda_release_version"
 
@@ -180,7 +165,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
 
         cordapp project(':contracts')
         cordapp project(':workflows')
-        cordapp("net.corda:corda-finance-contracts:$corda_release_version")
+        cordapp("$corda_core_release_group:corda-finance-contracts:$corda_release_version")
         cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
         cordapp("$corda_release_group:corda-confidential-identities:$corda_release_version")
         rpcUsers = [[ user: "user1", "password": "password", "permissions": ["ALL"]]]

--- a/Accounts/obligation-accounts/contracts/build.gradle
+++ b/Accounts/obligation-accounts/contracts/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_core_release_group:corda-finance-workflows:$corda_release_version"
     cordapp "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
-    cordapp "$corda_release_group:corda-finance-workflows:$corda_release_version"
+    cordapp "$corda_core_release_group:corda-finance-workflows:$corda_release_version"
     cordapp("$corda_release_group:corda-confidential-identities:$corda_release_version")
     // Token Account dependencies.
     cordaProvided "$accounts_release_group:accounts-contracts:$accounts_release_version"

--- a/Accounts/obligation-accounts/contracts/build.gradle
+++ b/Accounts/obligation-accounts/contracts/build.gradle
@@ -21,9 +21,9 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
 
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_core_release_group:corda-finance-workflows:$corda_release_version"
-    cordapp "net.corda:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_release_group:corda-finance-workflows:$corda_release_version"
     cordapp("$corda_release_group:corda-confidential-identities:$corda_release_version")
     // Token Account dependencies.

--- a/Accounts/obligation-accounts/contracts/build.gradle
+++ b/Accounts/obligation-accounts/contracts/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
     // Corda dependencies.
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
-    testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-node-driver:$corda_release_version"
 
     cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_core_release_group:corda-finance-workflows:$corda_release_version"

--- a/Accounts/obligation-accounts/repositories.gradle
+++ b/Accounts/obligation-accounts/repositories.gradle
@@ -1,30 +1,11 @@
-/*
- * Required only for build the samples with Corda Enterprise
- */
-ext.artifactory_contextUrl = 'https://software.r3.com/artifactory'
-ext.cordaArtifactoryUsername = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: ''
-ext.cordaArtifactoryPassword = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: ''
-
-
 repositories {
     mavenLocal()
     mavenCentral()
 
-    maven {
-        url "https://software.r3.com/artifactory/r3-corda-releases"
-        authentication {
-            basic(BasicAuthentication)
-        }
-        credentials {
-            username = cordaArtifactoryUsername
-            password = cordaArtifactoryPassword
-        }
-        mavenContent {
-            releasesOnly()
-        }
-    }
+    //
+    // Specify your own repos here, including any authentication details that are required.
+    //
     
-
     maven { url 'https://jitpack.io' }
     maven { url 'https://download.corda.net/maven/corda-dependencies' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }

--- a/Accounts/obligation-accounts/repositories.gradle
+++ b/Accounts/obligation-accounts/repositories.gradle
@@ -7,6 +7,5 @@ repositories {
     //
     
     maven { url 'https://jitpack.io' }
-    maven { url 'https://download.corda.net/maven/corda-dependencies' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }

--- a/Accounts/obligation-accounts/workflows/build.gradle
+++ b/Accounts/obligation-accounts/workflows/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_release_group:corda-finance-workflows:$corda_release_version"
 
-    testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-node-driver:$corda_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")

--- a/Accounts/obligation-accounts/workflows/build.gradle
+++ b/Accounts/obligation-accounts/workflows/build.gradle
@@ -53,14 +53,14 @@ dependencies {
     
     //finance 
     cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
-    cordaProvided "$corda_release_group:corda-finance-workflows:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-workflows:$corda_release_version"
 
     testImplementation "$corda_core_release_group:corda-node-driver:$corda_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")
     cordapp "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
-    cordapp "$corda_release_group:corda-finance-workflows:$corda_release_version"
+    cordapp "$corda_core_release_group:corda-finance-workflows:$corda_release_version"
     cordapp("$corda_release_group:corda-confidential-identities:$corda_release_version")
     //Account dependencies
     cordaProvided "$confidential_id_release_group:ci-workflows:$confidential_id_release_version"

--- a/Accounts/obligation-accounts/workflows/build.gradle
+++ b/Accounts/obligation-accounts/workflows/build.gradle
@@ -47,19 +47,19 @@ dependencies {
 
     // Corda dependencies.
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_core_release_group:corda-finance-workflows:$corda_release_version"
     cordaProvided "$corda_release_group:corda:$corda_release_version"
     
     //finance 
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_release_group:corda-finance-workflows:$corda_release_version"
 
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")
-    cordapp "net.corda:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_release_group:corda-finance-workflows:$corda_release_version"
     cordapp("$corda_release_group:corda-confidential-identities:$corda_release_version")
     //Account dependencies

--- a/Advanced/auction-cordapp/build.gradle
+++ b/Advanced/auction-cordapp/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     corda  "$corda_release_group:corda:$corda_release_version"
 
     // CorDapp dependencies.
-    cordapp("net.corda:corda-finance-contracts:$corda_release_version")
+    cordapp("$corda_core_release_group:corda-finance-contracts:$corda_release_version")
     cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
     cordapp project(":workflows")
     cordapp project(":contracts")
@@ -123,7 +123,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         projectCordapp {
             deploy = false
         }
-        cordapp("net.corda:corda-finance-contracts:$corda_release_version")
+        cordapp("$corda_core_release_group:corda-finance-contracts:$corda_release_version")
         cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
         cordapp project(':contracts')
         cordapp project(':workflows')

--- a/Advanced/auction-cordapp/client/build.gradle
+++ b/Advanced/auction-cordapp/client/build.gradle
@@ -9,7 +9,7 @@ cordapp {
 dependencies {
     // Corda dependencies.
     cordaProvided "$corda_release_group:corda-rpc:$corda_release_version"
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "net.corda:corda-core:$corda_release_version"
     cordaProvided "net.corda:corda-jackson:$corda_release_version"
     cordaProvided "net.corda:corda:$corda_release_version"
@@ -19,7 +19,7 @@ dependencies {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-logging"
     }
 
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_release_group:corda-finance-workflows:$corda_release_version"
     implementation "org.springframework.boot:spring-boot-devtools:$spring_boot_version"
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.3")

--- a/Advanced/auction-cordapp/contracts/build.gradle
+++ b/Advanced/auction-cordapp/contracts/build.gradle
@@ -14,8 +14,8 @@ cordapp {
 dependencies {
     // Corda dependencies.
     cordaProvided "$corda_release_group:corda-core:$corda_release_version"
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
-    cordaProvided  "$corda_release_group:corda:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_release_group:corda:$corda_release_version"
     cordaProvided "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
     cordaProvided "$corda_core_release_group:corda-test-utils:$corda_core_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"

--- a/Advanced/duediligence-cordapp/build.gradle
+++ b/Advanced/duediligence-cordapp/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     corda "$corda_release_group:corda:$corda_release_version"
 
     // CorDapp dependencies.
-    cordapp("net.corda:corda-finance-contracts:$corda_release_version")
+    cordapp("$corda_core_release_group:corda-finance-contracts:$corda_release_version")
     cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
     cordapp project(":workflows")
     cordapp project(":contracts")

--- a/Advanced/duediligence-cordapp/contracts/build.gradle
+++ b/Advanced/duediligence-cordapp/contracts/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
 
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
-    cordaProvided  "$corda_release_group:corda:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_release_group:corda:$corda_release_version"
     cordaProvided "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
     cordaProvided "$corda_core_release_group:corda-test-utils:$corda_core_release_version"
 

--- a/Advanced/negotiation-cordapp/build.gradle
+++ b/Advanced/negotiation-cordapp/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     corda "$corda_release_group:corda:$corda_release_version"
 
     // CorDapp dependencies.
-    cordapp("net.corda:corda-finance-contracts:$corda_release_version")
+    cordapp("$corda_core_release_group:corda-finance-contracts:$corda_release_version")
     cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
     cordapp project(":workflows")
     cordapp project(":contracts")

--- a/Advanced/negotiation-cordapp/contracts/build.gradle
+++ b/Advanced/negotiation-cordapp/contracts/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     // Corda dependencies.
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
 
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
-    cordaProvided  "$corda_release_group:corda:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_release_group:corda:$corda_release_version"
     cordaProvided "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
     cordaProvided "$corda_core_release_group:corda-test-utils:$corda_core_release_version"
 }

--- a/Advanced/obligation-cordapp/build.gradle
+++ b/Advanced/obligation-cordapp/build.gradle
@@ -120,7 +120,7 @@ sourceSets {
 dependencies {
     // Corda dependencies.
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_release_group:corda-finance-workflows:$corda_release_version"
 
     cordaBootstrapper "org.slf4j:slf4j-simple:$slf4j_version"
@@ -132,7 +132,7 @@ dependencies {
     // CorDapp dependencies.
     cordapp project(":workflows")
     cordapp project(":contracts")
-    cordapp "net.corda:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_release_group:corda-finance-workflows:$corda_release_version"
     cordapp "$corda_release_group:corda-confidential-identities:$corda_release_version"
 
@@ -155,7 +155,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         }
         cordapp project(':contracts')
         cordapp project(':workflows')
-        cordapp("net.corda:corda-finance-contracts:$corda_release_version")
+        cordapp("$corda_core_release_group:corda-finance-contracts:$corda_release_version")
         cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
         cordapp("$corda_release_group:corda-confidential-identities:$corda_release_version")
         rpcUsers = [[ user: "user1", "password": "password", "permissions": ["ALL"]]]

--- a/Advanced/obligation-cordapp/contracts/build.gradle
+++ b/Advanced/obligation-cordapp/contracts/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_core_release_group:corda-finance-workflows:$corda_release_version"
-    cordapp "net.corda:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_release_group:corda-finance-workflows:$corda_release_version"
     cordapp("$corda_release_group:corda-confidential-identities:$corda_release_version")
 
@@ -29,8 +29,8 @@ dependencies {
 
     // Corda dependencies.
 
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
-    cordaProvided  "$corda_release_group:corda:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_release_group:corda:$corda_release_version"
     cordaProvided "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
     cordaProvided "$corda_core_release_group:corda-test-utils:$corda_core_release_version"
 }

--- a/Advanced/obligation-cordapp/workflows/build.gradle
+++ b/Advanced/obligation-cordapp/workflows/build.gradle
@@ -51,14 +51,14 @@ dependencies {
     corda  "$corda_release_group:corda:$corda_release_version"
     
     //finance 
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_release_group:corda-finance-workflows:$corda_release_version"
 
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")
-    cordapp "net.corda:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_release_group:corda-finance-workflows:$corda_release_version"
     cordapp("$corda_release_group:corda-confidential-identities:$corda_release_version")
 

--- a/Advanced/superyacht-cordapp/build.gradle
+++ b/Advanced/superyacht-cordapp/build.gradle
@@ -111,11 +111,11 @@ dependencies {
         exclude group: "ch.qos.logback", module: "logback-classic"
     }
     corda "$corda_release_group:corda:$corda_release_version"
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_release_group:corda-finance-workflows:$corda_release_version"
 
     // CorDapp dependencies.
-    cordapp("net.corda:corda-finance-contracts:$corda_release_version")
+    cordapp("$corda_core_release_group:corda-finance-contracts:$corda_release_version")
     cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
     cordapp project(":workflows")
     cordapp project(":contracts")
@@ -146,7 +146,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         projectCordapp {
             deploy = false
         }
-        cordapp("net.corda:corda-finance-contracts:$corda_release_version")
+        cordapp("$corda_core_release_group:corda-finance-contracts:$corda_release_version")
         cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
         cordapp project(':contracts')
         cordapp project(':workflows')

--- a/Advanced/superyacht-cordapp/workflows/build.gradle
+++ b/Advanced/superyacht-cordapp/workflows/build.gradle
@@ -39,7 +39,7 @@ configurations {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    cordaProvided "net.corda:corda-finance-contracts:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-finance-contracts:$corda_release_version"
     cordaProvided "$corda_release_group:corda-finance-workflows:$corda_release_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "junit:junit:$junit_version"

--- a/Basic/cordapp-example/contracts/build.gradle
+++ b/Basic/cordapp-example/contracts/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
     cordaProvided "$corda_core_release_group:corda-test-utils:$corda_core_release_version"
-    cordaProvided "$corda_release_group:corda-node-driver:$corda_release_version"
+    cordaProvided "$corda_core_release_group:corda-node-driver:$corda_release_version"
 
     testImplementation "junit:junit:$junit_version"
 }

--- a/Basic/cordapp-example/workflows/build.gradle
+++ b/Basic/cordapp-example/workflows/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "$corda_core_release_group:corda-core:$corda_core_release_version"
-    testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-node-driver:$corda_release_version"
     testImplementation "junit:junit:$junit_version"
     testImplementation "io.reactivex:rxjava:$rxjava_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"

--- a/Basic/repositories.gradle
+++ b/Basic/repositories.gradle
@@ -1,42 +1,11 @@
-
-/*
- * Required only for build the samples with Corda Enterprise
- */
-ext.artifactory_contextUrl = 'https://software.r3.com/artifactory'
-ext.cordaArtifactoryUsername = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: ''
-ext.cordaArtifactoryPassword = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: ''
-
 repositories {
     mavenLocal()
     mavenCentral()
 
     maven { url 'https://jitpack.io' }
-    maven { url 'https://download.corda.net/maven/corda-dependencies' }
-    maven { url 'https://download.corda.net/maven/corda-releases' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 
-    maven {
-        url "$artifactory_contextUrl/r3-corda-releases"
-        authentication {
-            basic(BasicAuthentication)
-        }
-        credentials {
-            username = cordaArtifactoryUsername
-            password = cordaArtifactoryPassword
-        }
-        mavenContent {
-            releasesOnly()
-        }
-    }
-
-    maven {
-        url "$artifactory_contextUrl/r3-corda-dev"
-        content {
-            includeModule 'com.r3.corda', 'corda-shell'
-        }
-        credentials {
-            username = cordaArtifactoryUsername
-            password = cordaArtifactoryPassword
-        }
-    }
+    //
+    // Specify your own repos here, including any authentication details that are required.
+    //
 }

--- a/Basic/repositories.gradle
+++ b/Basic/repositories.gradle
@@ -4,6 +4,7 @@ repositories {
 
     maven { url 'https://jitpack.io' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven { url 'https://jcenter.bintray.com' }
 
     //
     // Specify your own repos here, including any authentication details that are required.


### PR DESCRIPTION
Updates primarily aimed at getting the `Accounts/obligation-cordapp` project to build against the Corda Ent 4.12 release pack.
Also changed some uses of `net.corda` to use the config var `corda_core_release_version`, for consistency.
The finance workflows and contracts are now both used from net.corda.