### PR TITLE
ENT-12069: Update URL to public repo in reference-states CorDapp

### DIFF
--- a/Features/referenceStates-sanctionsBody/build.gradle
+++ b/Features/referenceStates-sanctionsBody/build.gradle
@@ -52,7 +52,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url 'https://downloads.corda.net/maven/corda-releases'
+            url 'https://download.corda.net/maven/corda-releases'
         }
         mavenLocal()
     }

--- a/Features/referenceStates-sanctionsBody/build.gradle
+++ b/Features/referenceStates-sanctionsBody/build.gradle
@@ -52,7 +52,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url 'https://software.r3.com/artifactory/corda-releases'
+            url 'https://downloads.corda.net/maven'
         }
         mavenLocal()
     }

--- a/Features/referenceStates-sanctionsBody/build.gradle
+++ b/Features/referenceStates-sanctionsBody/build.gradle
@@ -52,7 +52,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            url 'https://downloads.corda.net/maven'
+            url 'https://downloads.corda.net/maven/corda-releases'
         }
         mavenLocal()
     }


### PR DESCRIPTION
The URL to the public-facing R3 repos has been moved from https://software.r3.com/artifactory to https://download.corda.net/maven. All CorDapps apart from this one use the new URL, and this one (reference-states CorDapp) needs to be updated too (must have been forgotten/missed).