### PR TITLE
Bridging via token move to self

### DIFF
--- a/Tokens/constants.properties
+++ b/Tokens/constants.properties
@@ -1,7 +1,7 @@
 cordaReleaseGroup=com.r3.corda
 cordaCoreReleaseGroup=net.corda
-cordaVersion=4.13-SNAPSHOT
-cordaCoreVersion=4.13-SNAPSHOT
+cordaVersion=4.14-SNAPSHOT
+cordaCoreVersion=4.14-SNAPSHOT
 gradlePluginsVersion=5.1.1
 kotlinVersion=1.9.20
 junitVersion=4.12

--- a/Tokens/constants.properties
+++ b/Tokens/constants.properties
@@ -10,3 +10,4 @@ log4jVersion =2.23.1
 platformVersion=140
 slf4jVersion=2.0.12
 nettyVersion=4.1.77.Final
+solana4jVersion=1.2.0

--- a/Tokens/stockpaydividend/build.gradle
+++ b/Tokens/stockpaydividend/build.gradle
@@ -17,10 +17,11 @@ buildscript {
         log4j_version = constants.getProperty("log4jVersion")
         slf4j_version = constants.getProperty("slf4jVersion")
         corda_platform_version = constants.getProperty("platformVersion").toInteger()
+        solana4j_version = constants.getProperty("solana4jVersion")
 
         //token
         tokens_release_group = 'com.r3.corda.lib.tokens'
-        tokens_release_version = '1.3-SNAPSHOT'
+        tokens_release_version = '1.3'
 
 
         testJvmArgs = ['--add-opens', 'java.base/java.time=ALL-UNNAMED', '--add-opens', 'java.base/java.io=ALL-UNNAMED',

--- a/Tokens/stockpaydividend/contracts/build.gradle
+++ b/Tokens/stockpaydividend/contracts/build.gradle
@@ -26,6 +26,10 @@ dependencies {
 
     // Token SDK dependencies.
     cordaProvided "$tokens_release_group:tokens-contracts:$tokens_release_version"
+
+    //App dependencies
+    cordaProvided "com.lmax:solana4j:${solana4j_version}"
+    cordaProvided "$corda_release_group:corda-solana-sdk:$corda_release_version"
 }
 
 test {

--- a/Tokens/stockpaydividend/contracts/src/main/kotlin/com/r3/corda/lib/tokens/bridging/contracts/BridgingContract.kt
+++ b/Tokens/stockpaydividend/contracts/src/main/kotlin/com/r3/corda/lib/tokens/bridging/contracts/BridgingContract.kt
@@ -1,0 +1,70 @@
+package com.r3.corda.lib.tokens.bridging.contracts
+
+import com.lmax.solana4j.programs.TokenProgramBase
+import com.r3.corda.lib.tokens.bridging.states.BridgedAssetLockState
+import com.r3.corda.lib.tokens.contracts.commands.MoveTokenCommand
+import com.r3.corda.lib.tokens.contracts.states.FungibleToken
+import net.corda.core.contracts.CommandData
+import net.corda.core.contracts.Contract
+import net.corda.core.identity.Party
+import net.corda.core.transactions.LedgerTransaction
+import net.corda.solana.sdk.instruction.Pubkey
+import net.corda.solana.sdk.instruction.SolanaInstruction
+import net.corda.solana.sdk.internal.Token2022
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class BridgingContract : Contract {
+    override fun verify(tx: LedgerTransaction) {
+        val bridgingCommands = tx.commandsOfType<BridgingCommand>()
+
+        require(bridgingCommands.size == 1) { "Bridging transactions must have single bridging command" }
+
+        when (val bridgingCommand = bridgingCommands.single().value) {
+            is BridgingCommand.BridgeToSolana -> verifyBridging(tx, bridgingCommand)
+        }
+    }
+
+    private fun verifyBridging(tx: LedgerTransaction, bridgingCommand: BridgingCommand.BridgeToSolana) {
+        val lockState = tx.outputsOfType<BridgedAssetLockState>().singleOrNull()
+
+        require(lockState != null) { "Bridging transaction must have exactly one BridgedAssetLockstate as output" }
+
+        require(lockState.participants.single() == bridgingCommand.bridgeAuthority) { "BridgedAssetLockstate must be owned by bridging authority" }
+
+        val moveCommands = tx.commandsOfType<MoveTokenCommand>()
+
+        require(moveCommands.size == 1) { "Bridging must have one move command to lock token" }
+
+        val lockedSum = tx.outputsOfType<FungibleToken>()
+            .filter { it.holder == bridgingCommand.bridgeAuthority } //TODO this is mute point for now, change to != bridgeAuthority, to filter only states owned by CI ..
+            .sumOf {
+                it.amount.toDecimal().toLong()
+            } // ... currently can't distinguish between locked and a change, both are for same holder ...
+
+        val instruction = tx.notaryInstructions.singleOrNull() as? SolanaInstruction
+
+        require(instruction != null) { "Exactly one Solana mint instruction required" }
+
+        require(instruction.programId == Token2022.PROGRAM_ID) { "Solana program id must be Token2022 program" }
+
+        require(instruction.accounts[1].pubkey == bridgingCommand.targetAddress) { "Target in instructions does not match command" }
+
+        @Suppress("MagicNumber")
+        require(instruction.data.size == 9) { "Expecting 9 bytes of instruction data" }
+
+        val instructionBytes = ByteBuffer.wrap(instruction.data.bytes).order(ByteOrder.LITTLE_ENDIAN)
+
+        val tokenInstruction = instructionBytes.get().toInt()
+
+        val amount = instructionBytes.getLong()
+        require(tokenInstruction == TokenProgramBase.MINT_TO_INSTRUCTION) { "Token instruction must be MINT_TO_INSTRUCTION" }
+
+        require(amount == lockedSum) { "Locked amount of $lockedSum must match requested mint amount $amount." }
+    }
+
+    sealed interface BridgingCommand : CommandData {
+
+        data class BridgeToSolana(val targetAddress: Pubkey, val bridgeAuthority: Party) : BridgingCommand
+    }
+}

--- a/Tokens/stockpaydividend/contracts/src/main/kotlin/com/r3/corda/lib/tokens/bridging/contracts/BridgingContract.kt
+++ b/Tokens/stockpaydividend/contracts/src/main/kotlin/com/r3/corda/lib/tokens/bridging/contracts/BridgingContract.kt
@@ -37,10 +37,11 @@ class BridgingContract : Contract {
         require(moveCommands.size == 1) { "Bridging must have one move command to lock token" }
 
         val lockedSum = tx.outputsOfType<FungibleToken>()
-            .filter { it.holder == bridgingCommand.bridgeAuthority } //TODO this is mute point for now, change to != bridgeAuthority, to filter only states owned by CI ..
+            .filter { it.holder == bridgingCommand.bridgeAuthority } // TODO this is mute point for now, change to != bridgeAuthority, to filter only states owned by CI ...
+            // ... currently can't distinguish between locked and a change, both are for same holder
             .sumOf {
                 it.amount.toDecimal().toLong()
-            } // ... currently can't distinguish between locked and a change, both are for same holder ...
+            }
 
         val instruction = tx.notaryInstructions.singleOrNull() as? SolanaInstruction
 

--- a/Tokens/stockpaydividend/contracts/src/main/kotlin/com/r3/corda/lib/tokens/bridging/contracts/BridgingContract.kt
+++ b/Tokens/stockpaydividend/contracts/src/main/kotlin/com/r3/corda/lib/tokens/bridging/contracts/BridgingContract.kt
@@ -37,7 +37,7 @@ class BridgingContract : Contract {
         require(moveCommands.size == 1) { "Bridging must have one move command to lock token" }
 
         val lockedSum = tx.outputsOfType<FungibleToken>()
-            .filter { it.holder == bridgingCommand.bridgeAuthority } // TODO this is mute point for now, change to != bridgeAuthority, to filter only states owned by CI ...
+            .filter { it.holder != bridgingCommand.bridgeAuthority }
             // ... currently can't distinguish between locked and a change, both are for same holder
             .sumOf {
                 it.amount.toDecimal().toLong()

--- a/Tokens/stockpaydividend/contracts/src/main/kotlin/com/r3/corda/lib/tokens/bridging/states/BridgedAssetLockState.kt
+++ b/Tokens/stockpaydividend/contracts/src/main/kotlin/com/r3/corda/lib/tokens/bridging/states/BridgedAssetLockState.kt
@@ -1,0 +1,9 @@
+package com.r3.corda.lib.tokens.bridging.states
+
+import com.r3.corda.lib.tokens.bridging.contracts.BridgingContract
+import net.corda.core.contracts.BelongsToContract
+import net.corda.core.contracts.ContractState
+import net.corda.core.identity.AbstractParty
+
+@BelongsToContract(BridgingContract::class)
+class BridgedAssetLockState(override val participants: List<AbstractParty>) : ContractState

--- a/Tokens/stockpaydividend/workflows/build.gradle
+++ b/Tokens/stockpaydividend/workflows/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     // Token SDK dependencies.
     cordaProvided "$tokens_release_group:tokens-contracts:$tokens_release_version"
     cordaProvided "$tokens_release_group:tokens-workflows:$tokens_release_version"
+
+    cordaProvided "$corda_release_group:corda-solana-sdk:$corda_release_version"
+    cordaProvided "$corda_release_group:corda-solana-common:$corda_release_version"
 }
 
 task integrationTest(type: Test, dependsOn: []) {

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/BridgeFungibleTokensFlow.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/BridgeFungibleTokensFlow.kt
@@ -2,15 +2,24 @@ package com.r3.corda.lib.tokens.bridging
 
 import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.lib.tokens.bridging.contracts.BridgingContract
+import com.r3.corda.lib.tokens.contracts.states.FungibleToken
 import com.r3.corda.lib.tokens.contracts.types.TokenType
+import com.r3.corda.lib.tokens.selection.TokenQueryBy
+import com.r3.corda.lib.tokens.selection.database.selector.DatabaseTokenSelection
 import com.r3.corda.lib.tokens.workflows.flows.move.AbstractMoveTokensFlow
 import com.r3.corda.lib.tokens.workflows.flows.move.addMoveFungibleTokens
+import com.r3.corda.lib.tokens.workflows.flows.move.addMoveTokens
 import com.r3.corda.lib.tokens.workflows.types.PartyAndAmount
+import net.corda.core.contracts.Amount
+import net.corda.core.contracts.Amount.Companion.sumOrThrow
 import net.corda.core.contracts.ContractState
+import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.FlowSession
+import net.corda.core.node.services.Vault
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.solana.sdk.instruction.Pubkey
+import java.util.UUID
 
 //Follows flow moves fungible tokens and adds bridging command and output state to the transaction
 class BridgeFungibleTokensFlow
@@ -23,19 +32,33 @@ constructor(
     val additionalCommand: BridgingContract.BridgingCommand,
     val destination: Pubkey,
     val mint: Pubkey,
-    val mintAuthority: Pubkey,
-    val queryCriteria: QueryCriteria? = null
+    val mintAuthority: Pubkey
 ) : AbstractMoveTokensFlow() {
 
     @Suspendable
     override fun addMove(transactionBuilder: TransactionBuilder) {
-        addMoveFungibleTokens(
-            transactionBuilder = transactionBuilder,
-            serviceHub = serviceHub,
-            partiesAndAmounts = listOf(partyAndAmount), //TODO change to Confidential Identity and change will be distributed to current holder (BI)
-            changeHolder = ourIdentity,
-            queryCriteria = queryCriteria
-        )
+
+        //TODO move to other flow
+        val criteria = QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.UNCONSUMED)
+
+        serviceHub.vaultService.queryBy(FungibleToken::class.java, criteria)
+
+        val tokens = serviceHub.vaultService
+            .queryBy(FungibleToken::class.java, criteria)
+            .states
+//            .filter { stateAndRef ->
+//                val data = stateAndRef.state.data
+//                val token = data.amount.token // IssuedTokenType
+//                val tokenType = token.tokenType // TokenType
+//                tokenType == FiatCurrency.getInstance("GBP") && data.holder == ourIdentity
+//                // You can also check token.issuer == someIssuer if you want a specific issuer
+//            }
+
+        val token = tokens[0].state.data
+        val holder = ourIdentity
+        val output = FungibleToken(token.amount, holder)
+        addMoveTokens(transactionBuilder = transactionBuilder, inputs = listOf(tokens[0]), outputs = listOf(output))
+
         val quantity = partyAndAmount.amount.toDecimal().toLong() //TODO
         bridgeToken(
             serviceHub,

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/BridgeFungibleTokensFlow.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/BridgeFungibleTokensFlow.kt
@@ -3,31 +3,20 @@ package com.r3.corda.lib.tokens.bridging
 import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.lib.tokens.bridging.contracts.BridgingContract
 import com.r3.corda.lib.tokens.contracts.states.FungibleToken
-import com.r3.corda.lib.tokens.contracts.types.TokenType
-import com.r3.corda.lib.tokens.selection.TokenQueryBy
-import com.r3.corda.lib.tokens.selection.database.selector.DatabaseTokenSelection
 import com.r3.corda.lib.tokens.workflows.flows.move.AbstractMoveTokensFlow
-import com.r3.corda.lib.tokens.workflows.flows.move.addMoveFungibleTokens
 import com.r3.corda.lib.tokens.workflows.flows.move.addMoveTokens
-import com.r3.corda.lib.tokens.workflows.types.PartyAndAmount
-import net.corda.core.contracts.Amount
-import net.corda.core.contracts.Amount.Companion.sumOrThrow
 import net.corda.core.contracts.ContractState
-import net.corda.core.flows.FlowLogic
+import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.FlowSession
-import net.corda.core.node.services.Vault
-import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.solana.sdk.instruction.Pubkey
-import java.util.UUID
 
-//Follows flow moves fungible tokens and adds bridging command and output state to the transaction
 class BridgeFungibleTokensFlow
 @JvmOverloads
 constructor(
-    val partyAndAmount: PartyAndAmount<TokenType>,
     override val participantSessions: List<FlowSession>,
     override val observerSessions: List<FlowSession> = emptyList(),
+    val token: StateAndRef<FungibleToken>,
     val additionalOutput: ContractState,
     val additionalCommand: BridgingContract.BridgingCommand,
     val destination: Pubkey,
@@ -38,28 +27,13 @@ constructor(
     @Suspendable
     override fun addMove(transactionBuilder: TransactionBuilder) {
 
-        //TODO move to other flow
-        val criteria = QueryCriteria.VaultQueryCriteria(status = Vault.StateStatus.UNCONSUMED)
+        val amount = token.state.data.amount
+        val holder = ourIdentity //TODO confidential identity
+        val output = FungibleToken(amount, holder)
+        addMoveTokens(transactionBuilder = transactionBuilder, inputs = listOf(token), outputs = listOf(output))
 
-        serviceHub.vaultService.queryBy(FungibleToken::class.java, criteria)
-
-        val tokens = serviceHub.vaultService
-            .queryBy(FungibleToken::class.java, criteria)
-            .states
-//            .filter { stateAndRef ->
-//                val data = stateAndRef.state.data
-//                val token = data.amount.token // IssuedTokenType
-//                val tokenType = token.tokenType // TokenType
-//                tokenType == FiatCurrency.getInstance("GBP") && data.holder == ourIdentity
-//                // You can also check token.issuer == someIssuer if you want a specific issuer
-//            }
-
-        val token = tokens[0].state.data
-        val holder = ourIdentity
-        val output = FungibleToken(token.amount, holder)
-        addMoveTokens(transactionBuilder = transactionBuilder, inputs = listOf(tokens[0]), outputs = listOf(output))
-
-        val quantity = partyAndAmount.amount.toDecimal().toLong() //TODO
+        val quantity = amount.toDecimal()
+            .toLong() //TODO this is quantity for Solana, should it be 1 to 1 what is bridged on Corda?
         bridgeToken(
             serviceHub,
             transactionBuilder,

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/BridgeFungibleTokensFlow.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/BridgeFungibleTokensFlow.kt
@@ -8,6 +8,7 @@ import com.r3.corda.lib.tokens.workflows.flows.move.addMoveTokens
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.flows.FlowSession
+import net.corda.core.identity.AbstractParty
 import net.corda.core.transactions.TransactionBuilder
 import net.corda.solana.sdk.instruction.Pubkey
 
@@ -21,14 +22,14 @@ constructor(
     val additionalCommand: BridgingContract.BridgingCommand,
     val destination: Pubkey,
     val mint: Pubkey,
-    val mintAuthority: Pubkey
+    val mintAuthority: Pubkey,
+    val holder: AbstractParty
 ) : AbstractMoveTokensFlow() {
 
     @Suspendable
     override fun addMove(transactionBuilder: TransactionBuilder) {
 
         val amount = token.state.data.amount
-        val holder = ourIdentity //TODO confidential identity
         val output = FungibleToken(amount, holder)
         addMoveTokens(transactionBuilder = transactionBuilder, inputs = listOf(token), outputs = listOf(output))
 

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/BridgeFungibleTokensFlow.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/BridgeFungibleTokensFlow.kt
@@ -1,0 +1,51 @@
+package com.r3.corda.lib.tokens.bridging
+
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.lib.tokens.bridging.contracts.BridgingContract
+import com.r3.corda.lib.tokens.contracts.types.TokenType
+import com.r3.corda.lib.tokens.workflows.flows.move.AbstractMoveTokensFlow
+import com.r3.corda.lib.tokens.workflows.flows.move.addMoveFungibleTokens
+import com.r3.corda.lib.tokens.workflows.types.PartyAndAmount
+import net.corda.core.contracts.ContractState
+import net.corda.core.flows.FlowSession
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.solana.sdk.instruction.Pubkey
+
+//Follows flow moves fungible tokens and adds bridging command and output state to the transaction
+class BridgeFungibleTokensFlow
+@JvmOverloads
+constructor(
+    val partyAndAmount: PartyAndAmount<TokenType>,
+    override val participantSessions: List<FlowSession>,
+    override val observerSessions: List<FlowSession> = emptyList(),
+    val additionalOutput: ContractState,
+    val additionalCommand: BridgingContract.BridgingCommand,
+    val destination: Pubkey,
+    val mint: Pubkey,
+    val mintAuthority: Pubkey,
+    val queryCriteria: QueryCriteria? = null
+) : AbstractMoveTokensFlow() {
+
+    @Suspendable
+    override fun addMove(transactionBuilder: TransactionBuilder) {
+        addMoveFungibleTokens(
+            transactionBuilder = transactionBuilder,
+            serviceHub = serviceHub,
+            partiesAndAmounts = listOf(partyAndAmount), //TODO change to Confidential Identity and change will be distributed to current holder (BI)
+            changeHolder = ourIdentity,
+            queryCriteria = queryCriteria
+        )
+        val quantity = partyAndAmount.amount.toDecimal().toLong() //TODO
+        bridgeToken(
+            serviceHub,
+            transactionBuilder,
+            additionalOutput,
+            additionalCommand,
+            destination,
+            mint,
+            mintAuthority,
+            quantity
+        )
+    }
+}

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/BridgeTokensUtilities.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/BridgeTokensUtilities.kt
@@ -1,0 +1,84 @@
+package com.r3.corda.lib.tokens.bridging
+
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.lib.tokens.bridging.contracts.BridgingContract
+import com.r3.corda.lib.tokens.contracts.states.AbstractToken
+import com.r3.corda.lib.tokens.contracts.types.IssuedTokenType
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.node.ServiceHub
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.solana.sdk.instruction.Pubkey
+import net.corda.solana.sdk.internal.Token2022
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.forEach
+
+/**
+ * Adds a set of bridging commands to a transaction using specific outputs.
+ */
+@Suspendable
+fun bridgeTokens(
+    serviceHub: ServiceHub,
+    transactionBuilder: TransactionBuilder,
+    additionalOutput: List<ContractState>,
+    additionalCommand: BridgingContract.BridgingCommand,
+    destination: Pubkey,
+    mint: Pubkey,
+    mintAuthority: Pubkey,
+    quantity: Long
+): TransactionBuilder {
+    transactionBuilder.inputStates()
+    val outputGroups: Map<IssuedTokenType, List<AbstractToken>> =
+        transactionBuilder.outputStates()
+            .map { it.data }
+            .filterIsInstance<AbstractToken>()
+            .groupBy { it.issuedTokenType }
+    val inputGroups: Map<IssuedTokenType, List<StateAndRef<AbstractToken>>> = transactionBuilder.inputStates()
+        .map { serviceHub.toStateAndRef<AbstractToken>(it) }.groupBy { it.state.data.issuedTokenType }
+
+    check(outputGroups.keys == inputGroups.keys) {
+        "Input and output token types must correspond to each other when moving tokensToIssue"
+    }
+
+    transactionBuilder.apply {
+
+        outputGroups.forEach { (issuedTokenType: IssuedTokenType, _: List<AbstractToken>) ->
+            val inputGroup = inputGroups[issuedTokenType]
+                ?: throw IllegalArgumentException("No corresponding inputs for the outputs issued token type: $issuedTokenType")
+            val keys = inputGroup.map { it.state.data.holder.owningKey }
+
+            additionalOutput.map {
+                addOutputState(it)
+            }
+
+            addCommand(additionalCommand, keys)
+        }
+    }
+    if (additionalCommand is BridgingContract.BridgingCommand.BridgeToSolana) {
+        val instruction = Token2022.mintTo(mint, destination, mintAuthority, quantity)
+        transactionBuilder.addNotaryInstruction(instruction)
+    }
+
+    return transactionBuilder
+}
+
+/**
+ * Adds a single bridging command to a transaction.
+ */
+@Suspendable
+fun bridgeToken(
+    serviceHub: ServiceHub,
+    transactionBuilder: TransactionBuilder,
+    additionalOutput: ContractState,
+    additionalCommand: BridgingContract.BridgingCommand,
+    destination: Pubkey,
+    mint: Pubkey,
+    mintAuthority: Pubkey,
+    quantity: Long
+): TransactionBuilder {
+    return bridgeTokens(
+        serviceHub, transactionBuilder, listOf(additionalOutput),
+        additionalCommand, destination, mint, mintAuthority, quantity
+    )
+}

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/rpc/BridgeTokens.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/rpc/BridgeTokens.kt
@@ -1,0 +1,154 @@
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.lib.tokens.contracts.types.TokenType
+import com.r3.corda.lib.tokens.workflows.flows.move.MoveTokensFlowHandler
+import com.r3.corda.lib.tokens.workflows.types.PartyAndAmount
+import com.r3.corda.lib.tokens.workflows.utilities.sessionsForParties
+import net.corda.core.contracts.Amount
+import net.corda.core.contracts.ContractState
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.FlowSession
+import net.corda.core.flows.InitiatedBy
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.flows.StartableByService
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.Party
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.transactions.SignedTransaction
+import com.r3.corda.lib.tokens.bridging.BridgeFungibleTokensFlow
+import com.r3.corda.lib.tokens.bridging.contracts.BridgingContract
+import com.r3.corda.lib.tokens.bridging.states.BridgedAssetLockState
+import com.r3.corda.lib.tokens.contracts.types.TokenPointer
+import net.corda.core.utilities.ProgressTracker
+import net.corda.samples.stockpaydividend.flows.utilities.QueryUtilities
+import net.corda.samples.stockpaydividend.states.StockState
+import net.corda.solana.sdk.instruction.Pubkey
+
+@InitiatingFlow
+@StartableByRPC
+class BridgeStock(
+    val symbol: String,
+    val quantity: Long,
+    val bridgeAuthority: Party,
+    val destination: Pubkey,
+    val mint: Pubkey,
+    val mintAuthority: Pubkey
+) : FlowLogic<String>() {
+
+    constructor(
+        symbol: String,
+        quantity: Long,
+        bridgeAuthority: Party,
+        destination: String,
+        mint: String,
+        mintAuthority: String
+    ) : this(
+        symbol,
+        quantity,
+        bridgeAuthority,
+        Pubkey.fromBase58(destination),
+        Pubkey.fromBase58(mint),
+        Pubkey.fromBase58(mintAuthority)
+    )
+
+    override val progressTracker = ProgressTracker()
+
+    @Suspendable
+    override fun call(): String {
+        // To get the transferring stock, we can get the StockState from the vault and get it's pointer
+        val stockPointer: TokenPointer<StockState> = QueryUtilities.queryStockPointer(symbol, serviceHub)
+
+        // With the pointer, we can get the create an instance of transferring Amount
+        val amount: Amount<TokenType> = Amount(quantity, stockPointer)
+
+        val additionalOutput: ContractState = BridgedAssetLockState(listOf(ourIdentity))
+        val additionalCommand = BridgingContract.BridgingCommand.BridgeToSolana(
+            destination,
+            bridgeAuthority
+        ) //, ourIdentity.owningKey, bridgeAuthority.owningKey)
+        //Use built-in flow for move tokens to the recipient
+        val stx = subFlow(
+            BridgeFungibleTokens(
+                amount,
+                ourIdentity,
+                additionalOutput,
+                additionalCommand,
+                destination,
+                mint,
+                mintAuthority
+            )
+        )
+
+        return ("\nBridged " + quantity + " " + symbol + " stocks to "
+                + ourIdentity.name.organisation + ".\nTransaction ID: " + stx.id)
+    }
+}
+
+/**
+ * Initiating flow used to bridge amounts of tokens of the same party, [partyAndAmount] specifies what amount of tokens is bridged to a participant.
+ *
+ * Call this for one [TokenType] at a time.
+ *
+ * @param partyAndAmount pairing party - amount of token that is to be moved to that party
+ * @param observers optional observing parties to which the transaction will be broadcast
+ * @param queryCriteria additional criteria for token selection
+ */
+@StartableByService
+@StartableByRPC
+@InitiatingFlow
+class BridgeFungibleTokens
+@JvmOverloads
+constructor(
+    val partyAndAmount: PartyAndAmount<TokenType>,
+    val observers: List<Party> = emptyList(),
+    val additionalOutput: ContractState,
+    val additionalCommand: BridgingContract.BridgingCommand,
+    val destination: Pubkey,
+    val mint: Pubkey,
+    val mintAuthority: Pubkey,
+    val queryCriteria: QueryCriteria? = null
+) : FlowLogic<SignedTransaction>() {
+
+    constructor(
+        amount: Amount<TokenType>, holder: AbstractParty, additionalOutput: ContractState,
+        additionalCommand: BridgingContract.BridgingCommand, destination: Pubkey, mint: Pubkey, mintAuthority: Pubkey
+    )
+            : this(
+        PartyAndAmount(holder, amount),
+        emptyList(),
+        additionalOutput,
+        additionalCommand,
+        destination,
+        mint,
+        mintAuthority
+    )
+
+    @Suspendable
+    override fun call(): SignedTransaction {
+        val participants = listOf(partyAndAmount.party)
+        val observerSessions = sessionsForParties(observers)
+        val participantSessions = sessionsForParties(participants)
+        return subFlow(
+            BridgeFungibleTokensFlow(
+                partyAndAmount = partyAndAmount,
+                participantSessions = participantSessions,
+                observerSessions = observerSessions,
+                additionalOutput = additionalOutput,
+                additionalCommand = additionalCommand,
+                destination = destination,
+                mint = mint,
+                mintAuthority = mintAuthority,
+                queryCriteria = queryCriteria
+            )
+        )
+    }
+}
+
+/**
+ * Responder flow for [BridgeFungibleTokens].
+ */
+@InitiatedBy(BridgeFungibleTokens::class)
+class BridgeFungibleTokensHandler(val otherSession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() = subFlow(MoveTokensFlowHandler(otherSession))
+}

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/rpc/BridgeTokens.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/rpc/BridgeTokens.kt
@@ -1,3 +1,5 @@
+package com.r3.corda.lib.tokens.bridging.rpc
+
 import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.lib.tokens.contracts.types.TokenType
 import com.r3.corda.lib.tokens.workflows.flows.move.MoveTokensFlowHandler

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/rpc/BridgeTokens.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/rpc/BridgeTokens.kt
@@ -1,28 +1,24 @@
 package com.r3.corda.lib.tokens.bridging.rpc
 
 import co.paralleluniverse.fibers.Suspendable
-import com.r3.corda.lib.tokens.contracts.types.TokenType
-import com.r3.corda.lib.tokens.workflows.flows.move.MoveTokensFlowHandler
-import com.r3.corda.lib.tokens.workflows.utilities.sessionsForParties
-import net.corda.core.contracts.ContractState
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowSession
-import net.corda.core.flows.InitiatedBy
-import net.corda.core.flows.InitiatingFlow
-import net.corda.core.flows.StartableByRPC
-import net.corda.core.flows.StartableByService
-import net.corda.core.identity.AbstractParty
-import net.corda.core.identity.Party
-import net.corda.core.node.services.vault.QueryCriteria
-import net.corda.core.transactions.SignedTransaction
 import com.r3.corda.lib.tokens.bridging.BridgeFungibleTokensFlow
 import com.r3.corda.lib.tokens.bridging.contracts.BridgingContract
 import com.r3.corda.lib.tokens.bridging.states.BridgedAssetLockState
 import com.r3.corda.lib.tokens.contracts.states.FungibleToken
+import com.r3.corda.lib.tokens.contracts.types.TokenType
+import com.r3.corda.lib.tokens.workflows.flows.move.MoveTokensFlowHandler
+import com.r3.corda.lib.tokens.workflows.utilities.sessionsForParties
+import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.StateAndRef
+import net.corda.core.flows.*
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.Party
 import net.corda.core.node.services.Vault
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.ProgressTracker
 import net.corda.solana.sdk.instruction.Pubkey
+import java.util.*
 
 @InitiatingFlow
 @StartableByRPC
@@ -102,7 +98,24 @@ constructor(
 
     @Suspendable
     override fun call(): SignedTransaction {
-        val participants = listOf(holder)  //TODO add confidentialIdentity
+        // TODO: at the moment we are generating the UUID for the confidential identity but in the future it should be configured
+        val confidentialIdentityID = UUID.randomUUID()
+        val confidentialIdentityPublicKey = serviceHub
+            .identityService
+            .publicKeysForExternalId(confidentialIdentityID)
+            .singleOrNull()
+        val confidentialIdentityPartyAndCertificate = if (confidentialIdentityPublicKey == null) {
+            serviceHub.keyManagementService.freshKeyAndCert(
+                identity = serviceHub.identityService.certificateFromKey(ourIdentity.owningKey)!!,
+                revocationEnabled = false,
+                externalId = confidentialIdentityID
+            )
+        } else {
+            serviceHub.identityService.certificateFromKey(confidentialIdentityPublicKey)
+                ?: throw IllegalStateException("Could not find certificate for key $confidentialIdentityPublicKey")
+        }
+
+        val participants = listOf(holder)
         val observerSessions = sessionsForParties(observers)
         val participantSessions = sessionsForParties(participants)
 
@@ -124,7 +137,8 @@ constructor(
                 additionalCommand = additionalCommand,
                 destination = destination,
                 mint = mint,
-                mintAuthority = mintAuthority
+                mintAuthority = mintAuthority,
+                confidentialIdentityPartyAndCertificate.party,
             )
         )
     }

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/rpc/BridgeTokens.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/rpc/BridgeTokens.kt
@@ -93,7 +93,6 @@ class BridgeStock(
  *
  * @param partyAndAmount pairing party - amount of token that is to be moved to that party
  * @param observers optional observing parties to which the transaction will be broadcast
- * @param queryCriteria additional criteria for token selection
  */
 @StartableByService
 @StartableByRPC
@@ -107,8 +106,7 @@ constructor(
     val additionalCommand: BridgingContract.BridgingCommand,
     val destination: Pubkey,
     val mint: Pubkey,
-    val mintAuthority: Pubkey,
-    val queryCriteria: QueryCriteria? = null
+    val mintAuthority: Pubkey
 ) : FlowLogic<SignedTransaction>() {
 
     constructor(
@@ -139,8 +137,7 @@ constructor(
                 additionalCommand = additionalCommand,
                 destination = destination,
                 mint = mint,
-                mintAuthority = mintAuthority,
-                queryCriteria = queryCriteria
+                mintAuthority = mintAuthority
             )
         )
     }

--- a/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
+++ b/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
@@ -273,8 +273,7 @@ class FlowTests {
         )
 
         network!!.runNetwork()
-        val result = future.get()
-        println(result)
+        future.get()
 
         val remainingStockStatesPages = company!!.services.vaultService.queryBy(StockState::class.java).states
         val remainingStockState = remainingStockStatesPages[0].state.data

--- a/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
+++ b/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
@@ -1,6 +1,6 @@
 package net.corda.samples.stockpaydividend
 
-import BridgeStock
+import com.r3.corda.lib.tokens.bridging.rpc.BridgeStock
 import com.r3.corda.lib.tokens.workflows.utilities.tokenBalance
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.CordaX500Name

--- a/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
+++ b/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
@@ -253,7 +253,7 @@ class FlowTests {
         val stockState = stockStatesPages[0].state.data
         val stockStatePointer = stockState.toPointer(stockState.javaClass)
         val (startCordaQuantity) = company!!.services.vaultService.tokenBalance(stockStatePointer)
-        Assert.assertEquals(2000L, startCordaQuantity)
+        Assert.assertEquals(ISSUING_STOCK_QUANTITY, startCordaQuantity)
 
         val startSolanaBalance =
             testValidator.client.getTokenAccountBalance(tokenAccount.base58(), RpcParams())
@@ -264,7 +264,7 @@ class FlowTests {
         future = company!!.startFlow(
             BridgeStock(
                 STOCK_SYMBOL,
-                ISSUING_STOCK_QUANTITY.toLong() /*BUYING_STOCK*/,
+                startCordaQuantity ,
                 company!!.info.legalIdentities[0],
                 tokenAccount.base58(),
                 tokenMint.base58(),
@@ -279,7 +279,7 @@ class FlowTests {
         val remainingStockState = remainingStockStatesPages[0].state.data
         val (quantity1) = company!!.services.vaultService.tokenBalance(remainingStockState.toPointer(remainingStockState.javaClass))
 
-        Assert.assertEquals(quantity1, java.lang.Long.valueOf(2000).toLong())
+        Assert.assertEquals(2000L, quantity1)
 
         val tokenPointer: TokenPointer<StockState> = stockState.toPointer(stockState.javaClass)
         val token: StateAndRef<FungibleToken>? =

--- a/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
+++ b/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
@@ -11,7 +11,9 @@ import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
 import net.corda.samples.stockpaydividend.flows.*
 import net.corda.samples.stockpaydividend.states.StockState
+import net.corda.solana.aggregator.common.RpcParams
 import net.corda.solana.aggregator.common.Signer
+import net.corda.solana.aggregator.common.checkResponse
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.TestIdentity
 import net.corda.testing.node.MockNetwork
@@ -226,6 +228,9 @@ class FlowTests {
         val (quantity) = company!!.services.vaultService.tokenBalance(stockState.toPointer(stockState.javaClass))
         Assert.assertEquals(quantity, java.lang.Long.valueOf(2000).toLong())
 
+        val startSolanaBalance =
+            testValidator.client.getBalance(accountOwner.account.base58(), RpcParams()).checkResponse("getBalance")
+
         // TODO Spend all to avoid having a change to yourself - then can't distinguish which amount si to mint which is a change
         future = company!!.startFlow(
             BridgeStock(
@@ -262,6 +267,11 @@ class FlowTests {
             "Bridge state and token are outputs of the same transaction",
             bridgingState!!.ref.txhash == token!!.ref.txhash
         )
+
+        val endSolanaBalance =
+            testValidator.client.getBalance(accountOwner.account.base58(), RpcParams()).checkResponse("getBalance")
+
+        Assert.assertEquals(startSolanaBalance, endSolanaBalance) //TODO check token account not total token balance
     }
 
 }

--- a/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
+++ b/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
@@ -4,14 +4,11 @@ import com.r3.corda.lib.tokens.bridging.rpc.BridgeStock
 import com.r3.corda.lib.tokens.bridging.states.BridgedAssetLockState
 import com.r3.corda.lib.tokens.contracts.states.FungibleToken
 import com.r3.corda.lib.tokens.contracts.types.TokenPointer
-import com.r3.corda.lib.tokens.workflows.utilities.heldTokensByToken
 import com.r3.corda.lib.tokens.workflows.utilities.tokenBalance
 import net.corda.core.contracts.StateAndRef
-import net.corda.core.contracts.StateRef
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
-import net.corda.core.node.services.Vault
 import net.corda.samples.stockpaydividend.flows.*
 import net.corda.samples.stockpaydividend.states.StockState
 import net.corda.solana.aggregator.common.Signer

--- a/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
+++ b/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
@@ -75,15 +75,17 @@ class FlowTests {
 
     @Before
     fun setup() {
-        network = MockNetwork(MockNetworkParameters(cordappsForAllNodes = listOf(
-                TestCordapp.findCordapp("net.corda.samples.stockpaydividend.contracts"),
-                TestCordapp.findCordapp("net.corda.samples.stockpaydividend.flows"),
-                TestCordapp.findCordapp("com.r3.corda.lib.tokens.contracts"),
-            TestCordapp.findCordapp("com.r3.corda.lib.tokens.workflows"),
-            DUMMY_CONTRACTS_CORDAPP
-        ), notarySpecs = listOf(MockNetworkNotarySpec(notaryName, notaryConfig = createNotaryConfig())),
-            networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
-        )
+        network = MockNetwork(
+            MockNetworkParameters(
+                cordappsForAllNodes = listOf(
+                    TestCordapp.findCordapp("net.corda.samples.stockpaydividend.contracts"),
+                    TestCordapp.findCordapp("net.corda.samples.stockpaydividend.flows"),
+                    TestCordapp.findCordapp("com.r3.corda.lib.tokens.contracts"),
+                    TestCordapp.findCordapp("com.r3.corda.lib.tokens.workflows"),
+                    DUMMY_CONTRACTS_CORDAPP
+                ), notarySpecs = listOf(MockNetworkNotarySpec(notaryName, notaryConfig = createNotaryConfig())),
+                networkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+            )
         )
 
         company = network!!.createPartyNode(COMPANY.name)
@@ -135,6 +137,7 @@ class FlowTests {
         Assert.assertNotNull(observerTx)
         Assert.assertEquals(issuerTx, observerTx)
     }
+
 
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)

--- a/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
+++ b/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
@@ -9,7 +9,8 @@ import net.corda.core.contracts.StateAndRef
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
-import net.corda.samples.stockpaydividend.flows.*
+import net.corda.samples.stockpaydividend.flows.CreateAndIssueStock
+import net.corda.samples.stockpaydividend.flows.MoveStock
 import net.corda.samples.stockpaydividend.states.StockState
 import net.corda.solana.aggregator.common.RpcParams
 import net.corda.solana.aggregator.common.Signer
@@ -17,26 +18,16 @@ import net.corda.solana.aggregator.common.checkResponse
 import net.corda.solana.sdk.internal.Token2022
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.TestIdentity
-import net.corda.testing.node.MockNetwork
-import net.corda.testing.node.MockNetworkParameters
-import net.corda.testing.node.StartedMockNode
-import net.corda.testing.node.TestCordapp
+import net.corda.testing.node.*
+import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
 import net.corda.testing.solana.SolanaTestValidator
-import org.junit.After
-import org.junit.AfterClass
-import org.junit.Assert
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
+import net.corda.testing.solana.randomKeypairFile
+import org.junit.*
+import org.junit.rules.TemporaryFolder
 import java.math.BigDecimal
+import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.ExecutionException
-import net.corda.testing.node.MockNetworkNotarySpec
-import net.corda.testing.node.internal.DUMMY_CONTRACTS_CORDAPP
-import net.corda.testing.solana.randomKeypairFile
-import org.junit.ClassRule
-import org.junit.rules.TemporaryFolder
-import java.nio.file.Path
 
 class FlowTests {
     private var network: MockNetwork? = null
@@ -61,6 +52,7 @@ class FlowTests {
     val STOCK_PRICE = BigDecimal.valueOf(7.4)
     val ISSUING_STOCK_QUANTITY = 2000
     val BUYING_STOCK = java.lang.Long.valueOf(500)
+    val HOLDING_IDENTITY_LABEL = "7045e3d6-90ac-4d85-a8a3-3b7e363f2c06"
 
 
     companion object {
@@ -269,7 +261,8 @@ class FlowTests {
                 company!!.info.legalIdentities[0],
                 tokenAccount.base58(),
                 tokenMint.base58(),
-                mintAuthority.account.base58()
+                mintAuthority.account.base58(),
+                HOLDING_IDENTITY_LABEL
             )
         )
 


### PR DESCRIPTION
Simplest bridging using tokens move to self. Token to bridge is just a first selected token (so it may only work once). 
Sung Mock Network to test with Solana local Network.
This is without Notary Chang, confidential identities and Bringing Authority. 
Bridge* flows follows the similar structure to Move flows from tokens SDK.
Currently (for development speed)  generic birding code is stock-sample and not in separate reusable repo.