### PR TITLE
ENT-14290: Implement SNAPSHOT dependency: referenceStates-sanctionsBody

### DIFF
--- a/Features/referenceStates-sanctionsBody/build.gradle
+++ b/Features/referenceStates-sanctionsBody/build.gradle
@@ -78,6 +78,9 @@ allprojects { //Properties that you need to compile your project (The applicatio
         maven { url 'https://download.corda.net/maven/corda-dependencies' }
         maven { url 'https://download.corda.net/maven/corda-lib' }
         maven { url 'https://jitpack.io' }
+
+        maven { url 'https://download.corda.net/maven/corda-dev' }
+        maven { url 'https://download.corda.net/maven/r3-corda-dev' }
     }
 
     java {


### PR DESCRIPTION
Jenkins Results (Tested on my Craft Branch)
ENT 4.12.7: [referencesStatesWorkAsAdvertised()](https://ci05.dev.r3.com/job/QA/job/CRAFT4/job/Utility/job/Test-Executor/2405/testReport/net.craft.scenarios.democordapps/ReferenceStatesSanctionBodyTests/referencesStatesWorkAsAdvertised__)
ENT 4.12-SNAPSHOT: [referencesStatesWorkAsAdvertised()](https://ci05.dev.r3.com/job/QA/job/CRAFT4/job/Utility/job/Test-Executor/2404/testReport/net.craft.scenarios.democordapps/ReferenceStatesSanctionBodyTests/referencesStatesWorkAsAdvertised__)


**Changes**
> Add corda maven dependencies in order to run Craft test for  `referenceStates-sanctionsBody` cordapp on 4.12-SNAPSHOT version
