### PR TITLE
Corda to Solana mappings in CordappConfig 

### DIFF
--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/SolanaAccountsMappingService.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/SolanaAccountsMappingService.kt
@@ -10,7 +10,7 @@ import net.corda.solana.sdk.instruction.Pubkey
 class SolanaAccountsMappingService(appServiceHub: AppServiceHub) : SingletonSerializeAsToken() {
     var participants: Map<CordaX500Name, Pubkey>
     var mints: Map<String, Pubkey>
-    var minAuthorities: Map<String, Pubkey>
+    var mintAuthorities: Map<String, Pubkey>
 
     // TODO quiet failover as this service is used in MockNetwork by nodes without a config for now
     // will be fail fast after separating flows to specific CordApps and adding Birding Authority which will have exclusive flows and this service
@@ -23,20 +23,20 @@ class SolanaAccountsMappingService(appServiceHub: AppServiceHub) : SingletonSeri
                 )
             }?.toMap() ?: emptyMap()
         } catch (_: Exception) {
-            emptyMap() // TODO see above
+            emptyMap()
         }
         mints = try {
             (cfg.get("mints") as? Map<String, String>)?.map { (k, v) -> k to Pubkey.fromBase58(v) }?.toMap()
                 ?: emptyMap()
         } catch (_: Exception) {
-            emptyMap() // TODO see above
+            emptyMap()
         }
 
-        minAuthorities = try {
+        mintAuthorities = try {
             (cfg.get("mintAuthorities") as? Map<String, String>)?.map { (k, v) -> k to Pubkey.fromBase58(v) }?.toMap()
                 ?: emptyMap()
         } catch (_: Exception) {
-            emptyMap() // TODO see above
+            emptyMap()
         }
     }
 }

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/SolanaAccountsMappingService.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/SolanaAccountsMappingService.kt
@@ -5,12 +5,13 @@ import net.corda.core.node.AppServiceHub
 import net.corda.core.node.services.CordaService
 import net.corda.core.serialization.SingletonSerializeAsToken
 import net.corda.solana.sdk.instruction.Pubkey
+import java.util.UUID
 
 @CordaService
 class SolanaAccountsMappingService(appServiceHub: AppServiceHub) : SingletonSerializeAsToken() {
     var participants: Map<CordaX500Name, Pubkey>
-    var mints: Map<String, Pubkey>
-    var mintAuthorities: Map<String, Pubkey>
+    var mints: Map<UUID, Pubkey>
+    var mintAuthorities: Map<UUID, Pubkey>
 
     // TODO quiet failover as this service is used in MockNetwork by nodes without a config for now
     // will be fail fast after separating flows to specific CordApps and adding Birding Authority which will have exclusive flows and this service
@@ -26,14 +27,19 @@ class SolanaAccountsMappingService(appServiceHub: AppServiceHub) : SingletonSeri
             emptyMap()
         }
         mints = try {
-            (cfg.get("mints") as? Map<String, String>)?.map { (k, v) -> k to Pubkey.fromBase58(v) }?.toMap()
+            (cfg.get("mints") as? Map<String, String>)?.map { (k, v) -> UUID.fromString(k) to Pubkey.fromBase58(v) }
+                ?.toMap()
                 ?: emptyMap()
         } catch (_: Exception) {
             emptyMap()
         }
 
         mintAuthorities = try {
-            (cfg.get("mintAuthorities") as? Map<String, String>)?.map { (k, v) -> k to Pubkey.fromBase58(v) }?.toMap()
+            (cfg.get("mintAuthorities") as? Map<String, String>)?.map { (k, v) ->
+                UUID.fromString(k) to Pubkey.fromBase58(
+                    v
+                )
+            }?.toMap()
                 ?: emptyMap()
         } catch (_: Exception) {
             emptyMap()

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/rpc/BridgeTokens.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/com/r3/corda/lib/tokens/bridging/rpc/BridgeTokens.kt
@@ -1,7 +1,6 @@
 package com.r3.corda.lib.tokens.bridging.rpc
 
 import co.paralleluniverse.fibers.Suspendable
-import com.r3.corda.lib.tokens.contracts.types.TokenType
 import com.r3.corda.lib.tokens.workflows.flows.move.MoveTokensFlowHandler
 import com.r3.corda.lib.tokens.workflows.utilities.sessionsForParties
 import net.corda.core.contracts.ContractState
@@ -61,15 +60,13 @@ class BridgeStock(
 }
 
 /**
- * Initiating flow used to bridge amounts of tokens of the same party.
- *
- * Call this for one [TokenType] at a time.
+ * Initiating flow used to bridge token of the same party.
  *
  * @param observers optional observing parties to which the transaction will be broadcast
  */
 @StartableByService
 @InitiatingFlow
-class BridgeFungibleTokens
+class BridgeFungibleTokens //TODO move away from RPC package
 @JvmOverloads
 constructor(
     val holder: AbstractParty,

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/CreateAndIssueStock.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/CreateAndIssueStock.kt
@@ -28,7 +28,9 @@ class CreateAndIssueStock(val symbol: String,
                           val currency: String,
                           val price: BigDecimal,
                           val issueVol: Int,
-                          val notary: Party) : FlowLogic<String>() {
+                          val notary: Party,
+                          val linearId: UniqueIdentifier = UniqueIdentifier()
+) : FlowLogic<String>() {
     override val progressTracker = ProgressTracker()
 
     @Suspendable
@@ -39,10 +41,7 @@ class CreateAndIssueStock(val symbol: String,
         val observers: List<Party> = getObserverLegalIdentities(identityService)
 
         // Construct the output StockState
-        val stockState = StockState(ourIdentity, symbol,
-                name, currency,
-                price,
-                UniqueIdentifier())
+        val stockState = StockState(ourIdentity, symbol, name, currency, price, linearId)
 
         // The notary provided here will be used in all future actions of this token
         val transactionState = stockState withNotary notary

--- a/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
+++ b/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
@@ -285,7 +285,7 @@ class FlowTests {
         future.get()
 
         // First stock to be bridged
-        var stockStatePointer = getTokensPointers(company!!, STOCK_SYMBOL).first()
+        var stockStatePointer = getTokensPointer(company!!, STOCK_SYMBOL)
         val (startCordaQuantity) = company!!.services.vaultService.tokenBalance(stockStatePointer)
         Assert.assertEquals(ISSUING_STOCK_QUANTITY.toLong(), startCordaQuantity)
 
@@ -295,7 +295,7 @@ class FlowTests {
         Assert.assertEquals("0", startSolanaBalance!!.amount)
 
         // Second stock - to verify it remains unaffected
-        var stock2StatePointer = getTokensPointers(company!!, STOCK_SYMBOL_2).first()
+        var stock2StatePointer = getTokensPointer(company!!, STOCK_SYMBOL_2)
         var (start2CordaQuantity) = company!!.services.vaultService.tokenBalance(stock2StatePointer)
         Assert.assertEquals(ISSUING_STOCK_QUANTITY.toLong(), start2CordaQuantity)
 
@@ -311,7 +311,7 @@ class FlowTests {
         network!!.runNetwork()
         future.get()
 
-        stockStatePointer = getTokensPointers(company!!, STOCK_SYMBOL).first()
+        stockStatePointer = getTokensPointer(company!!, STOCK_SYMBOL)
         val (finalCordaQuantity) = company!!.services.vaultService.tokenBalance(stockStatePointer)
         Assert.assertEquals(
             ISSUING_STOCK_QUANTITY.toLong(),
@@ -339,18 +339,19 @@ class FlowTests {
         Assert.assertEquals(ISSUING_STOCK_QUANTITY.toString(), finalSolanaBalance!!.amount)
 
         // Second stock balance remains unchanged /unaffected
-        stock2StatePointer = getTokensPointers(company!!, STOCK_SYMBOL_2).first()
+        stock2StatePointer = getTokensPointer(company!!, STOCK_SYMBOL_2)
         start2CordaQuantity = company!!.services.vaultService.tokenBalance(stock2StatePointer).quantity
         Assert.assertEquals(ISSUING_STOCK_QUANTITY.toLong(), start2CordaQuantity)
 
     }
 
 
-    private fun getTokensPointers(node: StartedMockNode, symbol: String): List<TokenPointer<StockState>> {
+    private fun getTokensPointer(node: StartedMockNode, symbol: String): TokenPointer<StockState> {
         val page =
-            node.services.vaultService.queryBy(StockState::class.java) //TODO + UNCONSUMED query  and belonging to our identity
+            node.services.vaultService.queryBy(StockState::class.java) //TODO + UNCONSUMED query and belonging to our identity
         val states = page.states.filter { it.state.data.symbol == symbol }
         val pointers: List<TokenPointer<StockState>> = states.map { it.state.data.toPointer(StockState::class.java) }
-        return pointers
+        Assert.assertEquals(1, pointers.size)
+        return pointers.first()
     }
 }

--- a/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
+++ b/Tokens/stockpaydividend/workflows/src/test/kotlin/net/corda/samples/stockpaydividend/FlowTests.kt
@@ -7,6 +7,7 @@ import com.r3.corda.lib.tokens.contracts.states.FungibleToken
 import com.r3.corda.lib.tokens.contracts.types.TokenPointer
 import com.r3.corda.lib.tokens.workflows.utilities.tokenBalance
 import net.corda.core.contracts.StateAndRef
+import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.crypto.SecureHash
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.identity.Party
@@ -63,7 +64,7 @@ class FlowTests {
     val STOCK_PRICE = BigDecimal.valueOf(7.4)
     val ISSUING_STOCK_QUANTITY = 2000
     val BUYING_STOCK = java.lang.Long.valueOf(500)
-
+    val LINEAR_ID = UniqueIdentifier()
 
     companion object {
         val notaryName = CordaX500Name("Solana Notary Service", "Zurich", "CH")
@@ -132,8 +133,8 @@ class FlowTests {
 
         val companyCfg = mapOf(
             "participants" to mapOf(COMPANY.name.toString() to tokenAccount.base58()),
-            "mints" to mapOf(STOCK_SYMBOL to tokenMint.base58()),
-            "mintAuthorities" to mapOf(STOCK_SYMBOL to mintAuthority.account.base58())
+            "mints" to mapOf(LINEAR_ID.toString() to tokenMint.base58()),
+            "mintAuthorities" to mapOf(LINEAR_ID.toString() to mintAuthority.account.base58())
         )
         company = network!!.createNode(
             MockNodeParameters(
@@ -227,6 +228,7 @@ class FlowTests {
         //Retrieve states from receiver
         val receivedStockStatesPages = shareholder!!.services.vaultService.queryBy(StockState::class.java).states
         val receivedStockState = receivedStockStatesPages[0].state.data
+        val cordaTokenId = receivedStockState.toPointer<StockState>().pointer.pointer.id
         val (quantity) = shareholder!!.services.vaultService.tokenBalance(
             receivedStockState.toPointer(
                 receivedStockState.javaClass
@@ -257,7 +259,8 @@ class FlowTests {
                 STOCK_CURRENCY,
                 STOCK_PRICE,
                 ISSUING_STOCK_QUANTITY,
-                notaryParty!!
+                notaryParty!!,
+                LINEAR_ID
             )
         )
         network!!.runNetwork()


### PR DESCRIPTION
Added Corapp config maps:
- Corda identity participant to Solana issuance address 
- Corda Token Symbol to Solana Mint Account
- Corda Token Symbol to Solana Mint Authority 
In the future future are used by Bridging Authority.
Added new CordaService to warp access to the mappings.

BridgingFlow doesn't get Solana Accounts data as Flow input, it's gets it from Cordapp config.

Refactor test - Solana accounts needed to be created before Corda Node is started to add relevant config info.