### PR TITLE
StockPayDividend code cleanup 

### DIFF
--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/AnnounceDividend.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/AnnounceDividend.kt
@@ -24,7 +24,8 @@ class AnnounceDividend(val symbol: String,
                        val payDate: Date) : FlowLogic<String>() {
     @Suspendable
     @Throws(FlowException::class)
-    override fun call(): String { // Retrieved the unconsumed StockState from the vault
+    override fun call(): String {
+        // Retrieved the unconsumed StockState from the vault
         val stockStateRef: StateAndRef<StockState> = QueryUtilities.queryStock(symbol, serviceHub)
         val stock: StockState = stockStateRef.state.data
 
@@ -33,7 +34,7 @@ class AnnounceDividend(val symbol: String,
 
         // Get predefined observers
         val identityService = serviceHub.identityService
-        val observers: List<Party> = getObserverLegalIdenties(identityService)!!
+        val observers: List<Party> = getObserverLegalIdentities(identityService)
         val obSessions: MutableList<FlowSession> = ArrayList()
         for (observer in observers) {
             obSessions.add(initiateFlow(observer))
@@ -41,23 +42,23 @@ class AnnounceDividend(val symbol: String,
         // Update the stock state and send a copy to the observers eventually
         val stx = subFlow(UpdateEvolvableTokenFlow(stockStateRef, outputState, listOf(), obSessions))
         subFlow(UpdateDistributionListFlow(stx))
-        return "Stock ${symbol} has changed dividend percentage to ${dividendPercentage}. ${stx.id}"
+        return "Stock $symbol has changed dividend percentage to ${dividendPercentage}. ${stx.id}"
     }
 }
 
 @InitiatedBy(AnnounceDividend::class)
 class AnnounceDividendResponder(val counterpartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
-    override fun call():Unit {
+    override fun call() {
         // To implement the responder flow, simply call the subflow of UpdateEvolvableTokenFlowHandler
         return subFlow(UpdateEvolvableTokenFlowHandler(counterpartySession))
     }
 }
 
-fun getObserverLegalIdenties(identityService: IdentityService): List<Party>? {
-    var observers: MutableList<Party> = ArrayList()
+fun getObserverLegalIdentities(identityService: IdentityService): List<Party> {
+    val observers: MutableList<Party> = ArrayList()
     for (observerName in listOf("Observer", "Shareholder")) {
-        val observerSet = identityService.partiesFromName(observerName!!, false)
+        val observerSet = identityService.partiesFromName(observerName, false)
         if (observerSet.size != 1) {
             val errMsg = String.format("Found %d identities for the observer.", observerSet.size)
             throw IllegalStateException(errMsg)

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/ClaimDividendReceivable.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/ClaimDividendReceivable.kt
@@ -26,8 +26,10 @@ import java.util.*
 @StartableByRPC
 class ClaimDividendReceivable(val symbol: String) : FlowLogic<String>() {
     @Suspendable
-    override fun call(): String { // Retrieve the stock and pointer
+    override fun call(): String {
+        // Retrieve the stock and pointer
         val stockPointer: TokenPointer<*> = QueryUtilities.queryStockPointer(symbol, serviceHub)
+        @Suppress("UNCHECKED_CAST")
         val stockStateRef: StateAndRef<StockState> = stockPointer.pointer.resolve(serviceHub) as StateAndRef<StockState>
         val stockState: StockState = stockStateRef.state.data
 
@@ -70,21 +72,22 @@ class ClaimDividendReceivable(val symbol: String) : FlowLogic<String>() {
 class ClaimDividendReceivableResponder(private val holderSession: FlowSession) : FlowLogic<SignedTransaction?>() {
     @Suspendable
     @Throws(FlowException::class)
-    override fun call(): SignedTransaction { // Receives shareholder's state for input and output
-
+    override fun call(): SignedTransaction {
+        // Receives shareholder's state for input and output
         val holderStockStates: List<StateAndRef<StockState>> = subFlow(ReceiveStateAndRefFlow(holderSession))
         val holderStockState: StateAndRef<StockState> = holderStockStates[0]
         val stockState: StockState = holderStockState.state.data
 
         // Query the stored state of the company
         val stockPointer: TokenPointer<*> = QueryUtilities.queryStockPointer(stockState.symbol, serviceHub)
+        @Suppress("UNCHECKED_CAST")
         val stockStateRef: StateAndRef<StockState> = stockPointer.pointer.resolve(serviceHub) as StateAndRef<StockState>
 
         // Receives the amount that the shareholder holds
-        val claimNoticication:ClaimNotification = holderSession.receive(ClaimNotification::class.java).unwrap { it: ClaimNotification->
-            if(holderStockState.ref.txhash != stockStateRef.ref.txhash){
+        val claimNotification:ClaimNotification = holderSession.receive(ClaimNotification::class.java).unwrap { it: ClaimNotification->
+            if (holderStockState.ref.txhash != stockStateRef.ref.txhash) {
                 throw FlowException("StockState does not match with the issuers. Shareholder may not have updated the newest stock state.")
-            }else{
+            } else {
                 it
             }
         }
@@ -94,7 +97,7 @@ class ClaimDividendReceivableResponder(private val holderSession: FlowSession) :
         val dividendTokenType = TokenType(currency.currencyCode, currency.defaultFractionDigits)
 
         // Calculate the actual dividend paying to the shareholder
-        val yield: BigDecimal = stockState.dividend.multiply(BigDecimal.valueOf(claimNoticication.amount.quantity))
+        val yield: BigDecimal = stockState.dividend.multiply(BigDecimal.valueOf(claimNotification.amount.quantity))
         val dividend = `yield`.multiply(stockState.price).multiply(BigDecimal.valueOf(
                 Math.pow(10.0, currency.defaultFractionDigits.toDouble())))
 
@@ -118,9 +121,7 @@ class ClaimDividendReceivableResponder(private val holderSession: FlowSession) :
         val stx = subFlow(CollectSignaturesFlow(ptx, sessions))
         return subFlow(FinalityFlow(stx, sessions))
     }
-
 }
-
 
 @CordaSerializable
 class ClaimNotification(val amount: Amount<TokenType>)

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/CreateAndIssueStock.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/CreateAndIssueStock.kt
@@ -32,11 +32,11 @@ class CreateAndIssueStock(val symbol: String,
     override val progressTracker = ProgressTracker()
 
     @Suspendable
-    override fun call():String {
+    override fun call(): String {
 
         // Sample specific - retrieving the hard-coded observers
         val identityService = serviceHub.identityService
-        val observers: List<Party> = getObserverLegalIdenties(identityService)!!
+        val observers: List<Party> = getObserverLegalIdentifies(identityService)
 
         // Construct the output StockState
         val stockState = StockState(ourIdentity, symbol,
@@ -54,7 +54,7 @@ class CreateAndIssueStock(val symbol: String,
         // Similar in IssueMoney flow, class of IssuedTokenType represents the stock is issued by the company party
         val issuedStock = stockState.toPointer(stockState.javaClass) issuedBy ourIdentity
 
-        // Create an specified amount of stock with a pointer that refers to the StockState
+        // Create a specified amount of stock with a pointer that refers to the StockState
         val issueAmount = Amount(issueVol.toLong(), issuedStock)
 
         // Indicate the recipient which is the issuing party itself here
@@ -66,10 +66,10 @@ class CreateAndIssueStock(val symbol: String,
                 + price + " " + currency + "\nTransaction ID: " + stx.id)
     }
 
-    fun getObserverLegalIdenties(identityService: IdentityService): List<Party>? {
-        var observers: MutableList<Party> = ArrayList()
+    fun getObserverLegalIdentifies(identityService: IdentityService): List<Party> {
+        val observers: MutableList<Party> = ArrayList()
         for (observerName in listOf("Observer")) {
-            val observerSet = identityService.partiesFromName(observerName!!, false)
+            val observerSet = identityService.partiesFromName(observerName, false)
             if (observerSet.size != 1) {
                 val errMsg = String.format("Found %d identities for the observer.", observerSet.size)
                 throw IllegalStateException(errMsg)

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/IssueMoney.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/IssueMoney.kt
@@ -21,7 +21,7 @@ class IssueMoney(val currency: String,
     override val progressTracker = ProgressTracker()
 
     @Suspendable
-    override fun call():String {
+    override fun call(): String {
 
         // Create an instance of the fiat currency token type
         val token = getInstance(currency)
@@ -32,7 +32,7 @@ class IssueMoney(val currency: String,
         // Create an instance of FungibleToken for the fiat currency to be issued
         val fungibleToken = FungibleToken(Amount(amount, issuedTokenType), recipient, null)
 
-        // Use the build-in flow, IssueTokens, to issue the required amount to the the recipient
+        // Use the build-in flow, IssueTokens, to issue the required amount to the recipient
         val stx = subFlow(IssueTokens(listOf(fungibleToken), listOf(recipient)))
         return ("\nIssued to " + recipient.name.organisation + " " + this.amount + " "
                 + this.currency + " for stock issuance." + "\nTransaction ID: " + stx.id)

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/MoveStock.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/MoveStock.kt
@@ -24,15 +24,13 @@ class MoveStock(val symbol: String,
     override val progressTracker = ProgressTracker()
 
     @Suspendable
-    override fun call():String {
+    override fun call(): String {
         // To get the transferring stock, we can get the StockState from the vault and get it's pointer
         val stockPointer: TokenPointer<StockState> = QueryUtilities.queryStockPointer(symbol, serviceHub)
 
-        // With the pointer, we can get the create an instance of transferring Amount
-        // With the pointer, we can get the create an instance of transferring Amount
+        // With the pointer, we can get an instance of transferring Amount
         val amount: Amount<TokenType> = Amount(quantity, stockPointer)
 
-        //Use built-in flow for move tokens to the recipient
         //Use built-in flow for move tokens to the recipient
         val stx = subFlow<SignedTransaction>(MoveFungibleTokens(amount, recipient))
         return ("\nIssued " + quantity + " " + symbol + " stocks to "

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/PayDividend.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/PayDividend.kt
@@ -2,10 +2,8 @@ package net.corda.samples.stockpaydividend.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.lib.tokens.contracts.states.FungibleToken
-import com.r3.corda.lib.tokens.contracts.types.TokenType
 import com.r3.corda.lib.tokens.selection.database.selector.DatabaseTokenSelection
 import com.r3.corda.lib.tokens.workflows.flows.move.addMoveTokens
-import com.r3.corda.lib.tokens.workflows.types.PartyAndAmount
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.requireThat
 import net.corda.core.flows.*
@@ -29,19 +27,17 @@ class PayDividend : FlowLogic<List<String>>() {
     override val progressTracker = ProgressTracker()
 
     @Suspendable
-    override fun call():List<String>  {
-        //Query the vault for any unconsumed DividendState
+    override fun call(): List<String>  {
         //Query the vault for any unconsumed DividendState
         val stateAndRefs: List<StateAndRef<DividendState>> = serviceHub.vaultService.queryBy<DividendState>().states
 
-        val transactions: List<SignedTransaction> = ArrayList()
-        var notes: MutableList<String> = ArrayList()
+        val notes: MutableList<String> = ArrayList()
         //For each queried unpaid DividendState, pay off the dividend with the corresponding amount.
         for (result in stateAndRefs) {
             val dividendState: DividendState = result.state.data
             val shareholder: Party = dividendState.shareholder
 
-            // Generate input and output pair of moving fungible tokens
+            // Generate input and output a pair of moving fungible tokens
             val fiatIoPair = DatabaseTokenSelection(serviceHub).generateMove(listOf(Pair(shareholder,dividendState.dividendAmount)),ourIdentity)
 
             // Using the notary from the previous transaction (dividend issuance)
@@ -70,7 +66,7 @@ class PayDividend : FlowLogic<List<String>>() {
             val stx = subFlow(CollectSignaturesFlow(ptx, listOf(holderSession)))
             val fstx = subFlow<SignedTransaction>(FinalityFlow(stx, sessions))
             notes.add("\nPaid to " + dividendState.shareholder.name.organisation
-                    .toString() + " " + (dividendState.dividendAmount.quantity / 100).toString() + " "
+                    + " " + (dividendState.dividendAmount.quantity / 100).toString() + " "
                     + dividendState.dividendAmount.token.tokenIdentifier + "\nTransaction ID: " + fstx.id)
         }
         return notes
@@ -80,8 +76,7 @@ class PayDividend : FlowLogic<List<String>>() {
 @InitiatedBy(PayDividend::class)
 class PayDividendResponder(val counterpartySession: FlowSession) : FlowLogic<SignedTransaction>() {
     @Suspendable
-    override fun call():SignedTransaction {
-        // Override the SignTransactionFlow for custom checkings
+    override fun call(): SignedTransaction {
         // Override the SignTransactionFlow for custom checkings
         class SignTxFlow (otherPartyFlow: FlowSession, progressTracker: ProgressTracker) : SignTransactionFlow(otherPartyFlow, progressTracker) {
             @Throws(FlowException::class)
@@ -99,6 +94,5 @@ class PayDividendResponder(val counterpartySession: FlowSession) : FlowLogic<Sig
         // Checks if the later transaction ID of the received FinalityFlow is the same as the one just signed
         val txId = subFlow(signTxFlow).id
         return subFlow(ReceiveFinalityFlow(counterpartySession, txId))
-
     }
 }

--- a/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/QueryFlows.kt
+++ b/Tokens/stockpaydividend/workflows/src/main/kotlin/net/corda/samples/stockpaydividend/flows/QueryFlows.kt
@@ -2,10 +2,8 @@ package net.corda.samples.stockpaydividend.flows
 
 import co.paralleluniverse.fibers.Suspendable
 import com.r3.corda.lib.tokens.contracts.types.TokenPointer
-import com.r3.corda.lib.tokens.contracts.types.TokenType
 import com.r3.corda.lib.tokens.money.FiatCurrency.Companion.getInstance
 import com.r3.corda.lib.tokens.workflows.utilities.tokenBalance
-import net.corda.core.contracts.Amount
 import net.corda.core.flows.FlowException
 import net.corda.core.flows.FlowLogic
 import net.corda.core.flows.InitiatingFlow
@@ -41,6 +39,5 @@ class GetFiatBalance(private val currencyCode: String) : FlowLogic<String>() {
         val fiatTokenType = getInstance(currencyCode)
         val amount =  serviceHub.vaultService.tokenBalance(fiatTokenType)
         return "You currently have ${amount.quantity/100} ${amount.token.tokenIdentifier}"
-
     }
 }


### PR DESCRIPTION
Clean up compilation wearings, formatting, duplicated comments, misspelled "private" function names.
This aims is to remove compilation warnings when building  https://github.com/corda/samples-kotlin/pull/125.