### PR TITLE
Update dependencies; use second network in test against Solana devnet

### DIFF
--- a/Solana/bridging-token/README.md
+++ b/Solana/bridging-token/README.md
@@ -37,7 +37,7 @@ From the repository root:
 
 On Windows:
 ```bash
-gradlew.bat  clean integrationtest --tests net.corda.samples.solana.bridging.token.BridgingTokenDriverTest
+gradlew.bat clean integrationtest --tests net.corda.samples.solana.bridging.token.BridgingTokenDriverTest
 ```
 
 This runs the [`BridgingTokenDriverTest`](workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/BridgingTokenDriverTest.kt)
@@ -54,7 +54,7 @@ From the repository root:
 
 On Windows:
 ```bash
-gradlew.bat  clean integrationtest --tests net.corda.samples.solana.bridging.token.DevNetBridgingTokenDriverTest
+gradlew.bat clean integrationtest --tests net.corda.samples.solana.bridging.token.DevNetBridgingTokenDriverTest
 ```
 
 This runs the [`DevNetBridgingTokenDriverTest`](workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/DevNetBridgingTokenDriverTest.kt)
@@ -72,7 +72,7 @@ From the repository root:
 
 On Windows:
 ```bash
-gradlew.bat  clean integrationtest --tests net.corda.samples.solana.bridging.token.DevNetBridgingTokenDriverDemo
+gradlew.bat clean integrationtest --tests net.corda.samples.solana.bridging.token.DevNetBridgingTokenDriverDemo
 ```
 
 This runs the [`DevNetBridgingTokenDriverDemo`](workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/DevNetBridgingTokenDriverDemo.kt)

--- a/Solana/bridging-token/gradle.properties
+++ b/Solana/bridging-token/gradle.properties
@@ -1,1 +1,1 @@
-corda_bridging_token_release_version=0.1.1-20260202.173203-11
+corda_bridging_token_release_version=0.1.1-20260209.102450-19

--- a/Solana/bridging-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/BridgingTokenDriverTest.kt
+++ b/Solana/bridging-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/BridgingTokenDriverTest.kt
@@ -1,14 +1,12 @@
 package net.corda.samples.solana.bridging.token
 
-import com.r3.corda.lib.solana.bridging.token.flows.SavaFactory.toPublicKey
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.messaging.startFlow
+import net.corda.core.solana.Pubkey
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
 import net.corda.node.utilities.solana.AccountManagement
-import net.corda.node.utilities.solana.FileSigner
-import net.corda.node.utilities.solana.SolanaClient
 import net.corda.node.utilities.solana.TokenManagement
 import net.corda.node.utilities.solana.TokenProgram
 import net.corda.samples.stockpaydividend.flows.CreateAndIssueStock
@@ -16,6 +14,8 @@ import net.corda.samples.stockpaydividend.flows.GetStockBalance
 import net.corda.samples.stockpaydividend.flows.IssueMoney
 import net.corda.samples.stockpaydividend.flows.MoveStock
 import net.corda.samples.stockpaydividend.states.StockState
+import net.corda.solana.notary.common.FileSigner
+import net.corda.solana.notary.common.SolanaClient
 import net.corda.solana.sdk.Token2022
 import net.corda.testing.common.internal.eventually
 import net.corda.testing.common.internal.testNetworkParameters
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
-import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.io.TempDir
 import org.slf4j.LoggerFactory
 import software.sava.core.accounts.PublicKey
@@ -170,19 +169,19 @@ open class BridgingTokenDriverTest {
             mintAuthoritySigner,
             otherShareholderWallet.publicKey(),
             tokenMint,
-            Token2022.PROGRAM_ID.toPublicKey()
+            Token2022.PROGRAM_ID.toSava()
         )
         tokenManagement.createAta(
             mintAuthoritySigner,
             redemptionWalletForOtherShareholder.publicKey(),
             tokenMint,
-            Token2022.PROGRAM_ID.toPublicKey()
+            Token2022.PROGRAM_ID.toSava()
         )
         tokenManagement.createAta(
             mintAuthoritySigner,
             redemptionWalletForShareholder.publicKey(),
             tokenMint,
-            Token2022.PROGRAM_ID.toPublicKey()
+            Token2022.PROGRAM_ID.toSava()
         )
     }
 
@@ -199,7 +198,7 @@ open class BridgingTokenDriverTest {
                 "websocketUrl" to solanaWssUrl,
                 "notaryKeypairFile" to "${solanaNotarySigner.file}",
                 "custodiedKeysDir" to "$custodiedKeysDir",
-                "programWhitelist" to listOf(Token2022.PROGRAM_ID.toPublicKey().toBase58())
+                "programWhitelist" to listOf(Token2022.PROGRAM_ID.toSava().toBase58())
             )
         )
     )
@@ -487,7 +486,7 @@ open class BridgingTokenDriverTest {
         val pda = PublicKey.findProgramAddress(
             listOf(
                 this.toByteArray(),
-                Token2022.PROGRAM_ID.toPublicKey().toByteArray(),
+                Token2022.PROGRAM_ID.toSava().toByteArray(),
                 tokenMint.toByteArray()
             ),
             ataProgram
@@ -559,3 +558,5 @@ fun SolanaClient.getAccountInfo(tokenAccount: PublicKey): Token2022Account? {
 
 fun SolanaClient.getSolanaTokenBalance(tokenAccount: PublicKey): BigDecimal =
     this.call(SolanaRpcClient::getTokenAccountBalance, tokenAccount).amount.toBigDecimal()
+
+fun Pubkey.toSava(): PublicKey = PublicKey.createPubKey(bytes)

--- a/Solana/bridging-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/BridgingTokenDriverTest.kt
+++ b/Solana/bridging-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/BridgingTokenDriverTest.kt
@@ -45,7 +45,7 @@ import software.sava.core.tx.Instruction
 import software.sava.rpc.json.http.client.SolanaRpcClient
 import java.math.BigDecimal
 import java.nio.file.Path
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.ExecutionException
 
 open class BridgingTokenDriverTest {
@@ -169,19 +169,19 @@ open class BridgingTokenDriverTest {
             mintAuthoritySigner,
             otherShareholderWallet.publicKey(),
             tokenMint,
-            Token2022.PROGRAM_ID.toSava()
+            Token2022.PROGRAM_ID.toPublicKey()
         )
         tokenManagement.createAta(
             mintAuthoritySigner,
             redemptionWalletForOtherShareholder.publicKey(),
             tokenMint,
-            Token2022.PROGRAM_ID.toSava()
+            Token2022.PROGRAM_ID.toPublicKey()
         )
         tokenManagement.createAta(
             mintAuthoritySigner,
             redemptionWalletForShareholder.publicKey(),
             tokenMint,
-            Token2022.PROGRAM_ID.toSava()
+            Token2022.PROGRAM_ID.toPublicKey()
         )
     }
 
@@ -197,8 +197,7 @@ open class BridgingTokenDriverTest {
                 "rpcUrl" to solanaRpcUrl,
                 "websocketUrl" to solanaWssUrl,
                 "notaryKeypairFile" to "${solanaNotarySigner.file}",
-                "custodiedKeysDir" to "$custodiedKeysDir",
-                "programWhitelist" to listOf(Token2022.PROGRAM_ID.toSava().toBase58())
+                "custodiedKeysDir" to "$custodiedKeysDir"
             )
         )
     )
@@ -486,7 +485,7 @@ open class BridgingTokenDriverTest {
         val pda = PublicKey.findProgramAddress(
             listOf(
                 this.toByteArray(),
-                Token2022.PROGRAM_ID.toSava().toByteArray(),
+                Token2022.PROGRAM_ID.toPublicKey().toByteArray(),
                 tokenMint.toByteArray()
             ),
             ataProgram
@@ -559,4 +558,4 @@ fun SolanaClient.getAccountInfo(tokenAccount: PublicKey): Token2022Account? {
 fun SolanaClient.getSolanaTokenBalance(tokenAccount: PublicKey): BigDecimal =
     this.call(SolanaRpcClient::getTokenAccountBalance, tokenAccount).amount.toBigDecimal()
 
-fun Pubkey.toSava(): PublicKey = PublicKey.createPubKey(bytes)
+fun Pubkey.toPublicKey(): PublicKey = PublicKey.createPubKey(bytes)

--- a/Solana/bridging-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/DevNetBridgingTokenDriverTest.kt
+++ b/Solana/bridging-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/DevNetBridgingTokenDriverTest.kt
@@ -4,7 +4,6 @@ import net.corda.node.utilities.solana.AccountManagement
 import net.corda.node.utilities.solana.TokenManagement
 import net.corda.solana.notary.common.FileSigner
 import net.corda.solana.notary.common.SolanaClient
-import net.corda.solana.sdk.Token2022
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
@@ -30,8 +29,7 @@ open class DevNetBridgingTokenDriverTest : BridgingTokenDriverTest() {
                     "rpcUrl" to solanaRpcUrl,
                     "websocketUrl" to solanaWssUrl,
                     "notaryKeypairFile" to "${solanaNotarySigner.file}",
-                    "custodiedKeysDir" to "${Path.of(staticCustodiedKeysDir).toAbsolutePath()}",
-                    "programWhitelist" to listOf(Token2022.PROGRAM_ID.toSava().toBase58())
+                    "custodiedKeysDir" to "${Path.of(staticCustodiedKeysDir).toAbsolutePath()}"
                 )
             )
         )

--- a/Solana/bridging-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/DevNetBridgingTokenDriverTest.kt
+++ b/Solana/bridging-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridging/token/DevNetBridgingTokenDriverTest.kt
@@ -1,10 +1,9 @@
 package net.corda.samples.solana.bridging.token
 
-import com.r3.corda.lib.solana.bridging.token.flows.SavaFactory.toPublicKey
 import net.corda.node.utilities.solana.AccountManagement
-import net.corda.node.utilities.solana.FileSigner
-import net.corda.node.utilities.solana.SolanaClient
 import net.corda.node.utilities.solana.TokenManagement
+import net.corda.solana.notary.common.FileSigner
+import net.corda.solana.notary.common.SolanaClient
 import net.corda.solana.sdk.Token2022
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.driver.DriverParameters
@@ -32,7 +31,7 @@ open class DevNetBridgingTokenDriverTest : BridgingTokenDriverTest() {
                     "websocketUrl" to solanaWssUrl,
                     "notaryKeypairFile" to "${solanaNotarySigner.file}",
                     "custodiedKeysDir" to "${Path.of(staticCustodiedKeysDir).toAbsolutePath()}",
-                    "programWhitelist" to listOf(Token2022.PROGRAM_ID.toPublicKey().toBase58())
+                    "programWhitelist" to listOf(Token2022.PROGRAM_ID.toSava().toBase58())
                 )
             )
         )
@@ -40,9 +39,7 @@ open class DevNetBridgingTokenDriverTest : BridgingTokenDriverTest() {
 
     override fun startTestValidator() {
         val notaryKeyPath =
-            Paths.get("../../../../enterprise/solana-devnet/network-0-notary-1-key.json").toAbsolutePath().toString()
-        //TODO use this:
-        //     Paths.get("../../Dev7chG99tLCAny3PNYmBdyhaKEVcZnSTp3p1mKVb5m5.json").toAbsolutePath().toString()
+             Paths.get("../../Dev7chG99tLCAny3PNYmBdyhaKEVcZnSTp3p1mKVb5m5.json").toAbsolutePath().toString()
         solanaNotarySigner = FileSigner.read(Path.of(notaryKeyPath))
         solanaClient = SolanaClient(URI.create(solanaRpcUrl), URI.create(solanaWssUrl)).apply { start() }
         tokenManagement = TokenManagement(solanaClient)

--- a/Solana/constants.properties
+++ b/Solana/constants.properties
@@ -1,8 +1,8 @@
 cordaEnterpriseReleaseGroup=com.r3.corda
 cordaOsReleaseGroup=net.corda
-cordaEnterpriseVersion=4.14-20260115.004000-64
-cordaOsVersion=4.14-20260112.000800-73
-cordaSolanaNotaryVersion=0.1.2
+cordaEnterpriseVersion=4.14-20260206.004000-81
+cordaOsVersion=4.14-20260130_101700-d7fa3ea
+cordaSolanaNotaryVersion=0.2.0
 cordaTokensVersion=1.3.2
 savaCoreVersion=25.1.2-j17-2
 savaProgramsVersion=25.0.0-j17-1


### PR DESCRIPTION
Update to dependencies that use internally Sava only; update Corda OS with `SolanaInstruction` class.
These updates allow to run a test with against second registered Corda Network on Solana devnet.