### PR TITLE
Update to `corda-solana-toolkit` 0.1.5

### DIFF
--- a/Solana/bridge-token/build.gradle
+++ b/Solana/bridge-token/build.gradle
@@ -70,7 +70,6 @@ allprojects {
 }
 
 apply plugin: 'net.corda.plugins.cordapp'
-//apply plugin: 'net.corda.plugins.quasar-utils'
 
 dependencies {
     // Corda dependencies.
@@ -79,8 +78,8 @@ dependencies {
     cordapp "com.r3.corda.lib.tokens:tokens-contracts:$corda_tokens_release_version"
     cordapp "com.r3.corda.lib.tokens:tokens-workflows:$corda_tokens_release_version"
 
-    cordapp "com.r3.corda.lib.solana:corda-bridging-token-contracts:$corda_bridging_token_release_version"
-    cordapp "com.r3.corda.lib.solana:corda-bridging-token-workflows:$corda_bridging_token_release_version"
+    cordapp "com.r3.corda.lib.solana:bridge-authority-contracts:$corda_solana_toolkit_version"
+    cordapp "com.r3.corda.lib.solana:bridge-authority-workflows:$corda_solana_toolkit_version"
 
     cordapp "com.stockpaydividend:contracts:1.0"
     cordapp "com.stockpaydividend:workflows:1.0"

--- a/Solana/bridge-token/gradle.properties
+++ b/Solana/bridge-token/gradle.properties
@@ -1,1 +1,1 @@
-corda_bridging_token_release_version=0.1.1-20260209.102450-19
+corda_solana_toolkit_version=0.1.5

--- a/Solana/bridge-token/repositories.gradle
+++ b/Solana/bridge-token/repositories.gradle
@@ -40,6 +40,7 @@ repositories {
             password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
         }
     }
+    // TODO this is temporarily
     // For Corda Bridge Authority Cordapp
     maven { url 'https://software.r3.com/artifactory/corda-dependencies'
         credentials {

--- a/Solana/bridge-token/repositories.gradle
+++ b/Solana/bridge-token/repositories.gradle
@@ -20,14 +20,28 @@ repositories {
         }
     }
     maven {
+        url 'https://software.r3.com/artifactory/corda-releases'
+        credentials {
+            username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
+            password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+        }
+    }
+    maven {
         url 'https://software.r3.com/artifactory/r3-corda-releases'
         credentials {
             username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
             password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
         }
     }
-    // For Corda Tokens SDK
+    // For Corda Tokens Cordapp
     maven { url 'https://software.r3.com/artifactory/corda-lib'
+        credentials {
+            username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
+            password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+        }
+    }
+    // For Corda Bridge Authority Cordapp
+    maven { url 'https://software.r3.com/artifactory/corda-dependencies'
         credentials {
             username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
             password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')

--- a/Solana/bridge-token/workflows/build.gradle
+++ b/Solana/bridge-token/workflows/build.gradle
@@ -34,10 +34,6 @@ dependencies {
     cordaProvided "$corda_os_release_group:corda-core:$corda_os_release_version"
     cordaProvided "$corda_enterprise_release_group:corda:$corda_enterprise_release_version"
 
-    // Corda dependencies needed for SolanaClient.
-    cordaProvided "$corda_enterprise_release_group:corda-node:$corda_enterprise_release_version"
-    cordaProvided "software.sava:sava-rpc:$sava_core_version"
-
     cordaProvided "com.r3.corda.lib.tokens:tokens-contracts:$corda_tokens_release_version"
     cordaProvided "com.r3.corda.lib.tokens:tokens-workflows:$corda_tokens_release_version"
 
@@ -50,21 +46,22 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testImplementation "com.r3.corda.lib.solana:testing:$corda_solana_toolkit_version"
-    testImplementation "$corda_enterprise_release_group:corda-test-utils:$corda_enterprise_release_version"
-    testImplementation "$corda_enterprise_release_group:corda-test-common:$corda_enterprise_release_version"
-
     testImplementation "org.junit.jupiter:junit-jupiter:5.14.0"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.14.0"
 
+    // Corda dependencies.
     testImplementation "$corda_enterprise_release_group:corda-node:$corda_enterprise_release_version"
     testImplementation "$corda_enterprise_release_group:corda-node-api:$corda_enterprise_release_version"
     testImplementation "$corda_enterprise_release_group:corda-node-driver:$corda_enterprise_release_version"
     testImplementation "$corda_enterprise_release_group:corda-core-test-utils:$corda_enterprise_release_version"
+    testImplementation "$corda_enterprise_release_group:corda-test-utils:$corda_enterprise_release_version"
+    testImplementation "$corda_enterprise_release_group:corda-test-common:$corda_enterprise_release_version"
 
-    testImplementation "net.corda.solana.notary:testing:$corda_solana_notary_version"
-    testImplementation "software.sava:solana-programs:$sava_programs_version"
+    // Corda - Solana dependencies.
     testImplementation "software.sava:sava-rpc:$sava_core_version"
+    testImplementation "net.corda.solana.notary:testing:$corda_solana_notary_version"
+    testImplementation "com.r3.corda.lib.solana:testing:$corda_solana_toolkit_version"
+
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.14.0"
 }

--- a/Solana/bridge-token/workflows/build.gradle
+++ b/Solana/bridge-token/workflows/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     testImplementation "$corda_enterprise_release_group:corda-test-common:$corda_enterprise_release_version"
 
     // Corda - Solana dependencies.
-    testImplementation "software.sava:sava-rpc:$sava_core_version"
     testImplementation "net.corda.solana.notary:testing:$corda_solana_notary_version"
     testImplementation "com.r3.corda.lib.solana:testing:$corda_solana_toolkit_version"
 

--- a/Solana/bridge-token/workflows/build.gradle
+++ b/Solana/bridge-token/workflows/build.gradle
@@ -38,22 +38,19 @@ dependencies {
     cordaProvided "$corda_enterprise_release_group:corda-node:$corda_enterprise_release_version"
     cordaProvided "software.sava:sava-rpc:$sava_core_version"
 
-    cordaProvided "$corda_enterprise_release_group:corda-solana-sdk:$corda_enterprise_release_version"
-
     cordaProvided "com.r3.corda.lib.tokens:tokens-contracts:$corda_tokens_release_version"
     cordaProvided "com.r3.corda.lib.tokens:tokens-workflows:$corda_tokens_release_version"
 
-    cordapp "com.r3.corda.lib.solana:corda-bridging-token-workflows:$corda_bridging_token_release_version"
-    cordapp "com.r3.corda.lib.solana:corda-bridging-token-contracts:$corda_bridging_token_release_version"
+    cordapp "com.r3.corda.lib.solana:bridge-authority-workflows:$corda_solana_toolkit_version"
+    cordapp "com.r3.corda.lib.solana:bridge-authority-contracts:$corda_solana_toolkit_version"
 
     cordapp "com.stockpaydividend:contracts:1.0"
     cordapp "com.stockpaydividend:workflows:1.0"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "$corda_enterprise_release_group:corda-solana-sdk:$corda_enterprise_release_version"
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testImplementation "net.corda.solana.notary:common:$corda_solana_notary_version"
+    testImplementation "com.r3.corda.lib.solana:testing:$corda_solana_toolkit_version"
     testImplementation "$corda_enterprise_release_group:corda-test-utils:$corda_enterprise_release_version"
     testImplementation "$corda_enterprise_release_group:corda-test-common:$corda_enterprise_release_version"
 
@@ -65,7 +62,7 @@ dependencies {
     testImplementation "$corda_enterprise_release_group:corda-node-driver:$corda_enterprise_release_version"
     testImplementation "$corda_enterprise_release_group:corda-core-test-utils:$corda_enterprise_release_version"
 
-    //TODO these will be removed after ATA creation is moved to TokenManagement
+    testImplementation "net.corda.solana.notary:testing:$corda_solana_notary_version"
     testImplementation "software.sava:solana-programs:$sava_programs_version"
     testImplementation "software.sava:sava-rpc:$sava_core_version"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenDemo.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenDemo.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 class DevNetBridgeTokenDemo : DevNetBridgeTokenTest() {
 
     @Test
-    override fun `briding token test`() = driver(
+    fun `briding token demo`() = driver(
         DriverParameters(
             isDebug = false,
             inMemoryDB = false,
@@ -19,8 +19,8 @@ class DevNetBridgeTokenDemo : DevNetBridgeTokenTest() {
             cordappsForAllNodes = cordappsForAllNodes,
             networkParameters = testNetworkParameters(minimumPlatformVersion = 160).copy(notaries = emptyList()),
             notarySpecs = listOf(
-                NotarySpec(generalNotaryName, getSolanaNotaryConfig(), startInProcess = false),
-                NotarySpec(solanaNotaryName, getSolanaNotaryConfig(), startInProcess = false)
+                NotarySpec(generalNotaryName, getSolanaNotaryConfig(solanaNotarySigner), startInProcess = false),
+                NotarySpec(solanaNotaryName, getSolanaNotaryConfig(solanaNotarySigner), startInProcess = false)
             ),
             waitForAllNodesToFinish = true
         )

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenDemo.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenDemo.kt
@@ -5,13 +5,14 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.NotarySpec
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 
-// Shareholder: https://solscan.io/account/3Wuk6fKtqCzMppikC1S58vK3J5ZbqnbcZXkDhJUHCom7?cluster=devnet#portfolio
-// Other Shareholder https://solscan.io/account/AoDHzQwk7s6crxMcC1nptRVHAhd1LASEWbQmAQjCeBKj?cluster=devnet#portfolio
 class DevNetBridgeTokenDemo : DevNetBridgeTokenTest() {
 
+    private val log = LoggerFactory.getLogger(DevNetBridgeTokenDemo::class.java)
+
     @Test
-    fun `briding token demo`() = driver(
+    fun `dev net bridge token demo`() = driver(
         DriverParameters(
             isDebug = false,
             inMemoryDB = false,
@@ -25,8 +26,11 @@ class DevNetBridgeTokenDemo : DevNetBridgeTokenTest() {
             waitForAllNodesToFinish = true
         )
     ) {
-        log.info("\nStarting bridging test using Solana validator via $solanaRpcUrl...")
+        log.info("\nStarting bridge test using Solana validator via $solanaRpcUrl...")
         runtimeSetup()
-        log.info("\nBridging deployment is running, shut down Corda nodes externally to exit...")
+        log.info("\nBridge deployment is running, shut down Corda nodes externally to exit...")
+        log.info("\nShareholders wallets:")
+        log.info("\n Shareholder: https://solscan.io/account/3Wuk6fKtqCzMppikC1S58vK3J5ZbqnbcZXkDhJUHCom7?cluster=devnet#portfolio")
+        log.info("\n Other Shareholder https://solscan.io/account/AoDHzQwk7s6crxMcC1nptRVHAhd1LASEWbQmAQjCeBKj?cluster=devnet#portfolio")
     }
 }

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenDemo.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenDemo.kt
@@ -5,11 +5,8 @@ import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.NotarySpec
 import org.junit.jupiter.api.Test
-import org.slf4j.LoggerFactory
 
 class DevNetBridgeTokenDemo : DevNetBridgeTokenTest() {
-
-    private val log = LoggerFactory.getLogger(DevNetBridgeTokenDemo::class.java)
 
     @Test
     fun `dev net bridge token demo`() = driver(

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenTest.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenTest.kt
@@ -10,7 +10,6 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.NotarySpec
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.slf4j.LoggerFactory
 import software.sava.core.accounts.PublicKey
 import java.math.BigDecimal
 import java.net.URI
@@ -18,47 +17,43 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 open class DevNetBridgeTokenTest : TestBase() {
-
-    private val log = LoggerFactory.getLogger(DevNetBridgeTokenTest::class.java)
-
-    // A directory for Notary to store Corda participant key pairs for signing Solana transactions,
+    // A directory for Notary to load Corda participant key pairs for signing Solana transactions,
     // intentionally these are located in a different directory than Corda Notary Program key pair
-    protected val staticCustodiedKeysDir = "src/integrationTest/resources/custodiedKeys"
+    protected val custodiedKeysDir = "src/integrationTest/resources/custodiedKeys"
     protected lateinit var solanaNotarySigner: FileSigner
 
     fun getSolanaNotaryConfig(solanaNotarySigner: FileSigner) = mapOf<String, Any>(
             "notary" to mapOf(
                 "validating" to false,
                 "solana" to mapOf(
-                    "rpcUrl" to solanaRpcUrl,
-                    "websocketUrl" to solanaWebsocketUrl,
+                    "rpcUrl" to "$solanaRpcUrl",
+                    "websocketUrl" to "$solanaWebsocketUrl",
                     "notaryKeypairFile" to "${solanaNotarySigner.file}",
-                    "custodiedKeysDir" to "${Path.of(staticCustodiedKeysDir).toAbsolutePath()}"
+                    "custodiedKeysDir" to "${Path.of(custodiedKeysDir).toAbsolutePath()}"
                 )
             )
         )
 
     @BeforeEach
     fun setup() {
-        solanaRpcUrl = "https://api.devnet.solana.com"
-        solanaWebsocketUrl = "ws://api.devnet.solana.com"
-        val notaryKeyPath =
-            Paths.get("../../Dev7chG99tLCAny3PNYmBdyhaKEVcZnSTp3p1mKVb5m5.json").toAbsolutePath().toString()
-        solanaNotarySigner = FileSigner.read(Path.of(notaryKeyPath))
-        solanaClient = SolanaClient(URI.create(solanaRpcUrl), URI.create(solanaWebsocketUrl)).apply { start() }
+        solanaRpcUrl = URI.create("https://api.devnet.solana.com")
+        solanaWebsocketUrl = URI.create("ws://api.devnet.solana.com")
+        val notaryKeyPath = Paths.get("../../Dev7chG99tLCAny3PNYmBdyhaKEVcZnSTp3p1mKVb5m5.json").toAbsolutePath()
+        solanaNotarySigner = FileSigner.read(notaryKeyPath)
+        solanaClient = SolanaClient(solanaRpcUrl, solanaWebsocketUrl).apply { start() }
         tokenManagement = TokenManagement(solanaClient)
         accountManagement = AccountManagement(solanaClient)
 
         bridgeAuthoritySigner =
-            FileSigner.read(Path.of("$staticCustodiedKeysDir/bridgeAuthority.json").toAbsolutePath())
+            FileSigner.read(Path.of("$custodiedKeysDir/bridgeAuthority.json").toAbsolutePath())
         redemptionWalletForShareholder =
-            FileSigner.read(Path.of("$staticCustodiedKeysDir/redemptionWalletForShareholder.json").toAbsolutePath())
+            FileSigner.read(Path.of("$custodiedKeysDir/redemptionWalletForShareholder.json").toAbsolutePath())
         redemptionWalletForOtherShareholder =
             FileSigner.read(
-                Path.of("$staticCustodiedKeysDir/redemptionWalletForOtherShareholder.json").toAbsolutePath()
+                Path.of("$custodiedKeysDir/redemptionWalletForOtherShareholder.json").toAbsolutePath()
             )
         mintAuthoritySigner =
-            FileSigner.read(Path.of("$staticCustodiedKeysDir/mintAuthoritySigner.json").toAbsolutePath())
+            FileSigner.read(Path.of("$custodiedKeysDir/mintAuthoritySigner.json").toAbsolutePath())
         val otherKeysDir = "src/integrationTest/resources/other"
         shareholderWallet = FileSigner.read(Path.of("$otherKeysDir/shareholderWallet.json").toAbsolutePath())
         otherShareholderWallet = FileSigner.read(Path.of("$otherKeysDir/otherShareholderWallet.json").toAbsolutePath())

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenTest.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenTest.kt
@@ -79,32 +79,32 @@ open class DevNetBridgeTokenTest : TestBase() {
         tokenMint2 = PublicKey.fromBase58Encoded("AhZNYSxWTVCbXMcZNJv27e7G38G7auFaqx4zCBBfWikc")
 
         log.info("  Creating Solana Token.")
-        log.info("  Shareholder Token Account: ${shareholderWallet.toATA().toBase58()}")
-        log.info("  Other Shareholder Token Account: ${otherShareholderWallet.toATA().toBase58()}")
-        log.info("  Shareholder Redemption Token Account: ${redemptionWalletForShareholder.toATA().toBase58()}")
+        log.info("  Shareholder Token Account: ${shareholderWallet.deriveATA().toBase58()}")
+        log.info("  Other Shareholder Token Account: ${otherShareholderWallet.deriveATA().toBase58()}")
+        log.info("  Shareholder Redemption Token Account: ${redemptionWalletForShareholder.deriveATA().toBase58()}")
         log.info(
             "  Other Shareholder Redemption Token Account: ${
-                redemptionWalletForOtherShareholder.toATA().toBase58()
+                redemptionWalletForOtherShareholder.deriveATA().toBase58()
             }"
         )
 
-        val shareholderBalance = solanaClient.getSolanaTokenBalance(shareholderWallet.toATA())
+        val shareholderBalance = solanaClient.getSolanaTokenBalance(shareholderWallet.deriveATA())
         if (shareholderBalance > BigDecimal.ZERO) {
             log.info("  Shareholder Token Account cleanup - burn existing $shareholderBalance tokens")
             tokenManagement.burn(
                 shareholderWallet,
                 tokenMint,
-                shareholderWallet.toATA(),
+                shareholderWallet.deriveATA(),
                 shareholderBalance.toLong()
             )
         }
-        val otherShareholderBalance = solanaClient.getSolanaTokenBalance(otherShareholderWallet.toATA())
+        val otherShareholderBalance = solanaClient.getSolanaTokenBalance(otherShareholderWallet.deriveATA())
         if (otherShareholderBalance > BigDecimal.ZERO) {
             log.info("  Other Shareholder Token Account cleanup - burn existing $otherShareholderBalance tokens")
             tokenManagement.burn(
                 otherShareholderWallet,
                 tokenMint,
-                otherShareholderWallet.toATA(),
+                otherShareholderWallet.deriveATA(),
                 otherShareholderBalance.toLong()
             )
         }

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenTest.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenTest.kt
@@ -8,50 +8,57 @@ import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
 import net.corda.testing.node.NotarySpec
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import software.sava.core.accounts.PublicKey
 import java.math.BigDecimal
 import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
 
-open class DevNetBridgeTokenTest : BridgingTokenDriverTest() {
+open class DevNetBridgeTokenTest : TestBase() {
 
-    val solanaRpcUrl = "https://api.devnet.solana.com"
-    val solanaWssUrl = "ws://api.devnet.solana.com"
+    private val log = LoggerFactory.getLogger(DevNetBridgeTokenTest::class.java)
+
+    // A directory for Notary to store Corda participant key pairs for signing Solana transactions,
+    // intentionally these are located in a different directory than Corda Notary Program key pair
     protected val staticCustodiedKeysDir = "src/integrationTest/resources/custodiedKeys"
-    lateinit var solanaNotarySigner: FileSigner
+    protected lateinit var solanaNotarySigner: FileSigner
 
-    override fun getSolanaNotaryConfig(solanaNotarySigner: FileSigner) : Map<String, Any> {
-        return mapOf<String, Any>(
+    fun getSolanaNotaryConfig(solanaNotarySigner: FileSigner) = mapOf<String, Any>(
             "notary" to mapOf(
                 "validating" to false,
                 "solana" to mapOf(
                     "rpcUrl" to solanaRpcUrl,
-                    "websocketUrl" to solanaWssUrl,
+                    "websocketUrl" to solanaWebsocketUrl,
                     "notaryKeypairFile" to "${solanaNotarySigner.file}",
                     "custodiedKeysDir" to "${Path.of(staticCustodiedKeysDir).toAbsolutePath()}"
                 )
             )
         )
-    }
 
-    fun startTestValidator() {
+    @BeforeEach
+    fun setup() {
+        solanaRpcUrl = "https://api.devnet.solana.com"
+        solanaWebsocketUrl = "ws://api.devnet.solana.com"
         val notaryKeyPath =
-             Paths.get("../../Dev7chG99tLCAny3PNYmBdyhaKEVcZnSTp3p1mKVb5m5.json").toAbsolutePath().toString()
-        //solanaNotarySigner = FileSigner.read(Path.of(notaryKeyPath))
-        solanaClient = SolanaClient(URI.create(solanaRpcUrl), URI.create(solanaWssUrl)).apply { start() }
+            Paths.get("../../Dev7chG99tLCAny3PNYmBdyhaKEVcZnSTp3p1mKVb5m5.json").toAbsolutePath().toString()
+        solanaNotarySigner = FileSigner.read(Path.of(notaryKeyPath))
+        solanaClient = SolanaClient(URI.create(solanaRpcUrl), URI.create(solanaWebsocketUrl)).apply { start() }
         tokenManagement = TokenManagement(solanaClient)
         accountManagement = AccountManagement(solanaClient)
-    }
 
-    override fun setupAccounts() {
-        bridgeAuthoritySigner = FileSigner.read(Path.of("$staticCustodiedKeysDir/bridgeAuthority.json").toAbsolutePath())
+        bridgeAuthoritySigner =
+            FileSigner.read(Path.of("$staticCustodiedKeysDir/bridgeAuthority.json").toAbsolutePath())
         redemptionWalletForShareholder =
             FileSigner.read(Path.of("$staticCustodiedKeysDir/redemptionWalletForShareholder.json").toAbsolutePath())
         redemptionWalletForOtherShareholder =
-            FileSigner.read(Path.of("$staticCustodiedKeysDir/redemptionWalletForOtherShareholder.json").toAbsolutePath())
-        mintAuthoritySigner = FileSigner.read(Path.of("$staticCustodiedKeysDir/mintAuthoritySigner.json").toAbsolutePath())
+            FileSigner.read(
+                Path.of("$staticCustodiedKeysDir/redemptionWalletForOtherShareholder.json").toAbsolutePath()
+            )
+        mintAuthoritySigner =
+            FileSigner.read(Path.of("$staticCustodiedKeysDir/mintAuthoritySigner.json").toAbsolutePath())
         val otherKeysDir = "src/integrationTest/resources/other"
         shareholderWallet = FileSigner.read(Path.of("$otherKeysDir/shareholderWallet.json").toAbsolutePath())
         otherShareholderWallet = FileSigner.read(Path.of("$otherKeysDir/otherShareholderWallet.json").toAbsolutePath())
@@ -72,39 +79,39 @@ open class DevNetBridgeTokenTest : BridgingTokenDriverTest() {
         tokenMint2 = PublicKey.fromBase58Encoded("AhZNYSxWTVCbXMcZNJv27e7G38G7auFaqx4zCBBfWikc")
 
         log.info("  Creating Solana Token.")
-        log.info("  Shareholder Token Account: ${shareholderWallet.deriveATA().toBase58()}")
-        log.info("  Other Shareholder Token Account: ${otherShareholderWallet.deriveATA().toBase58()}")
-        log.info("  Shareholder Redemption Token Account: ${redemptionWalletForShareholder.deriveATA().toBase58()}")
+        log.info("  Shareholder Token Account: ${shareholderWallet.toATA().toBase58()}")
+        log.info("  Other Shareholder Token Account: ${otherShareholderWallet.toATA().toBase58()}")
+        log.info("  Shareholder Redemption Token Account: ${redemptionWalletForShareholder.toATA().toBase58()}")
         log.info(
             "  Other Shareholder Redemption Token Account: ${
-                redemptionWalletForOtherShareholder.deriveATA().toBase58()
+                redemptionWalletForOtherShareholder.toATA().toBase58()
             }"
         )
 
-        val shareholderBalance = solanaClient.getSolanaTokenBalance(shareholderWallet.deriveATA())
+        val shareholderBalance = solanaClient.getSolanaTokenBalance(shareholderWallet.toATA())
         if (shareholderBalance > BigDecimal.ZERO) {
             log.info("  Shareholder Token Account cleanup - burn existing $shareholderBalance tokens")
             tokenManagement.burn(
                 shareholderWallet,
                 tokenMint,
-                shareholderWallet.deriveATA(),
+                shareholderWallet.toATA(),
                 shareholderBalance.toLong()
             )
         }
-        val otherShareholderBalance = solanaClient.getSolanaTokenBalance(otherShareholderWallet.deriveATA())
+        val otherShareholderBalance = solanaClient.getSolanaTokenBalance(otherShareholderWallet.toATA())
         if (otherShareholderBalance > BigDecimal.ZERO) {
             log.info("  Other Shareholder Token Account cleanup - burn existing $otherShareholderBalance tokens")
             tokenManagement.burn(
                 otherShareholderWallet,
                 tokenMint,
-                otherShareholderWallet.deriveATA(),
+                otherShareholderWallet.toATA(),
                 otherShareholderBalance.toLong()
             )
         }
     }
 
     @Test
-    fun `dev net briding token test`() = driver(
+    fun `dev net bridge token test`() = driver(
         DriverParameters(
             isDebug = false,
             inMemoryDB = false,

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenTest.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/DevNetBridgeTokenTest.kt
@@ -1,9 +1,9 @@
 package net.corda.samples.solana.bridge.token
 
-import net.corda.node.utilities.solana.AccountManagement
-import net.corda.node.utilities.solana.TokenManagement
-import net.corda.solana.notary.common.FileSigner
-import net.corda.solana.notary.common.SolanaClient
+import com.r3.corda.lib.solana.core.AccountManagement
+import com.r3.corda.lib.solana.core.FileSigner
+import com.r3.corda.lib.solana.core.SolanaClient
+import com.r3.corda.lib.solana.core.tokens.TokenManagement
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.driver.DriverParameters
 import net.corda.testing.driver.driver
@@ -17,11 +17,12 @@ import java.nio.file.Paths
 
 open class DevNetBridgeTokenTest : BridgingTokenDriverTest() {
 
-    override val solanaRpcUrl = "https://api.devnet.solana.com"
-    override val solanaWssUrl = "ws://api.devnet.solana.com"
+    val solanaRpcUrl = "https://api.devnet.solana.com"
+    val solanaWssUrl = "ws://api.devnet.solana.com"
     protected val staticCustodiedKeysDir = "src/integrationTest/resources/custodiedKeys"
+    lateinit var solanaNotarySigner: FileSigner
 
-    override fun getSolanaNotaryConfig() : Map<String, Any> {
+    override fun getSolanaNotaryConfig(solanaNotarySigner: FileSigner) : Map<String, Any> {
         return mapOf<String, Any>(
             "notary" to mapOf(
                 "validating" to false,
@@ -35,10 +36,10 @@ open class DevNetBridgeTokenTest : BridgingTokenDriverTest() {
         )
     }
 
-    override fun startTestValidator() {
+    fun startTestValidator() {
         val notaryKeyPath =
              Paths.get("../../Dev7chG99tLCAny3PNYmBdyhaKEVcZnSTp3p1mKVb5m5.json").toAbsolutePath().toString()
-        solanaNotarySigner = FileSigner.read(Path.of(notaryKeyPath))
+        //solanaNotarySigner = FileSigner.read(Path.of(notaryKeyPath))
         solanaClient = SolanaClient(URI.create(solanaRpcUrl), URI.create(solanaWssUrl)).apply { start() }
         tokenManagement = TokenManagement(solanaClient)
         accountManagement = AccountManagement(solanaClient)
@@ -102,10 +103,8 @@ open class DevNetBridgeTokenTest : BridgingTokenDriverTest() {
         }
     }
 
-    override fun stopTestValidator() = Unit
-
     @Test
-    override fun `briding token test`() = driver(
+    fun `dev net briding token test`() = driver(
         DriverParameters(
             isDebug = false,
             inMemoryDB = false,
@@ -114,7 +113,7 @@ open class DevNetBridgeTokenTest : BridgingTokenDriverTest() {
             networkParameters = testNetworkParameters(minimumPlatformVersion = 160).copy(notaries = emptyList()),
             notarySpecs = listOf(
                 NotarySpec(generalNotaryName, validating = false, startInProcess = false),
-                NotarySpec(solanaNotaryName, getSolanaNotaryConfig(), startInProcess = false)
+                NotarySpec(solanaNotaryName, getSolanaNotaryConfig(solanaNotarySigner), startInProcess = false)
             ),
             waitForAllNodesToFinish = false
         )

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/LocalNetBridgeTokenTest.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/LocalNetBridgeTokenTest.kt
@@ -13,14 +13,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
-import org.slf4j.LoggerFactory
 import java.nio.file.Path
 
 @ExtendWith(SolanaNotaryExtension::class)
 open class LocalNetBridgeTokenTest : TestBase() {
-
-    private val log = LoggerFactory.getLogger(LocalNetBridgeTokenTest::class.java)
-
     private lateinit var validator: SolanaTestValidator
 
     // A directory for Notary to store Corda participant key pairs for signing Solana transactions,
@@ -35,21 +31,22 @@ open class LocalNetBridgeTokenTest : TestBase() {
         "notary" to mapOf(
             "validating" to false,
             "solana" to mapOf(
-                "rpcUrl" to solanaRpcUrl,
-                "websocketUrl" to solanaWebsocketUrl,
+                "rpcUrl" to "$solanaRpcUrl",
+                "websocketUrl" to "$solanaWebsocketUrl",
                 "notaryKeypairFile" to "${solanaNotarySigner.file}",
                 "custodiedKeysDir" to "$custodiedKeysDir"
             )
         )
     )
+
     @BeforeEach
     fun setup(validator: SolanaTestValidator) {
         this.validator = validator
         solanaClient = validator.client()
         tokenManagement = validator.tokens()
         accountManagement = validator.accounts()
-        solanaRpcUrl = validator.rpcUrl().toString()
-        solanaWebsocketUrl = validator.websocketUrl().toString()
+        solanaRpcUrl = validator.rpcUrl()
+        solanaWebsocketUrl = validator.websocketUrl()
 
         bridgeAuthoritySigner = FileSigner.random(custodiedKeysDir)
         redemptionWalletForShareholder = FileSigner.random(custodiedKeysDir)
@@ -74,8 +71,8 @@ open class LocalNetBridgeTokenTest : TestBase() {
         accountManagement.airdropSol(mintAuthoritySigner.publicKey(), 1)
 
         // Stockpaydividend doesn't use fractionDigits, in order to maintain 1:1 conversion with Solana token,
-        // Solana token will not have fraction digits as well
-        val tokenDecimals: Int = 0
+        // Solana token will not have fraction digits either
+        val tokenDecimals = 0
 
         tokenMint =
             tokenManagement.createToken(mintAuthoritySigner, TokenProgram.TOKEN_2022, decimals = tokenDecimals)

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/LocalNetBridgeTokenTest.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/LocalNetBridgeTokenTest.kt
@@ -1,119 +1,56 @@
 package net.corda.samples.solana.bridge.token
 
-import net.corda.core.identity.CordaX500Name
-import net.corda.core.messaging.startFlow
-import net.corda.core.solana.Pubkey
-import net.corda.core.utilities.NetworkHostAndPort
-import net.corda.core.utilities.getOrThrow
-import net.corda.core.utilities.seconds
-import com.r3.corda.lib.solana.core.AccountManagement
 import com.r3.corda.lib.solana.core.FileSigner
-import com.r3.corda.lib.solana.core.SolanaClient
-import com.r3.corda.lib.solana.core.cordautils.Token2022
-import com.r3.corda.lib.solana.core.tokens.TokenManagement
 import com.r3.corda.lib.solana.core.tokens.TokenProgram
-import net.corda.samples.stockpaydividend.flows.CreateAndIssueStock
-import net.corda.samples.stockpaydividend.flows.GetStockBalance
-import net.corda.samples.stockpaydividend.flows.IssueMoney
-import net.corda.samples.stockpaydividend.flows.MoveStock
-import net.corda.samples.stockpaydividend.states.StockState
-import net.corda.testing.common.internal.eventually
-import net.corda.testing.common.internal.testNetworkParameters
-import net.corda.testing.core.singleIdentity
-import net.corda.testing.driver.DriverDSL
-import net.corda.testing.driver.DriverParameters
-import net.corda.testing.driver.NodeHandle
-import net.corda.testing.driver.NodeParameters
-import net.corda.testing.driver.driver
-import net.corda.testing.node.NotarySpec
-import net.corda.testing.node.TestCordapp
-import net.corda.testing.node.User
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertNotNull
-import org.junit.jupiter.api.io.TempDir
-import org.slf4j.LoggerFactory
-import software.sava.core.accounts.PublicKey
-import software.sava.core.accounts.Signer
-import software.sava.core.accounts.SolanaAccounts
-import software.sava.core.accounts.token.Token2022Account
-import software.sava.rpc.json.http.client.SolanaRpcClient
-import java.math.BigDecimal
-import java.nio.file.Path
-import java.util.UUID
-import java.util.concurrent.ExecutionException
 import com.r3.corda.lib.solana.testing.SolanaTestValidator
 import net.corda.solana.notary.testing.Notary
 import net.corda.solana.notary.testing.SolanaNotaryExtension
+import net.corda.testing.common.internal.testNetworkParameters
+import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.driver
+import net.corda.testing.node.NotarySpec
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
 
 @ExtendWith(SolanaNotaryExtension::class)
-open class BridgingTokenDriverTest {
+open class LocalNetBridgeTokenTest : TestBase() {
 
-    protected val log = LoggerFactory.getLogger(BridgingTokenDriverTest::class.java)
+    private val log = LoggerFactory.getLogger(LocalNetBridgeTokenTest::class.java)
+
     private lateinit var validator: SolanaTestValidator
-    protected lateinit var tokenManagement: TokenManagement
-    protected lateinit var accountManagement: AccountManagement
-    protected lateinit var solanaClient: SolanaClient
 
-    protected val solanaNotaryName = CordaX500Name("Solana Notary", "London", "GB")
-    protected val generalNotaryName = CordaX500Name("Notary", "London", "GB")
-    private val bridgeAuthority = CordaX500Name("Bridge Authority", "New York", "US")
-    private val shareholderName = CordaX500Name("Shareholder", "New York", "US")
-    private val otherShareholderName = CordaX500Name("Other Shareholder", "Frankfurt", "DE")
-
-    protected val cordappsForAllNodes =
-        listOf(
-            TestCordapp.findCordapp("com.r3.corda.lib.tokens.contracts"),
-            TestCordapp.findCordapp("com.r3.corda.lib.tokens.workflows"),
-            TestCordapp.findCordapp("net.corda.samples.stockpaydividend.states"),
-            TestCordapp.findCordapp("net.corda.samples.stockpaydividend.contracts"),
-            TestCordapp.findCordapp("net.corda.samples.stockpaydividend.flows").withConfig(
-                mapOf("notary" to "O=Notary,L=London,C=GB") // Solana Notary is an additional notary in the Corda network in this sample
-                // set preferred notary for flows that don't receive a notary as parameters (e.g. flows in Corda Tokens SDK)
-            )
-        )
-    val bridgingContracts = TestCordapp.findCordapp("com.r3.corda.lib.solana.bridging.token.contracts")
-    var bridgingWorkflowsWithoutConfig = TestCordapp.findCordapp("com.r3.corda.lib.solana.bridging.token.flows")
-
-    val rpcUsers = listOf(User("user1", "test", permissions = setOf("ALL")))
-
-    // Stockpaydividend doesn't use fractionDigits, in order to maintain 1:1 conversion with Solana token,
-    // Solana token will not have fraction digits as well
-    protected val TOKEN_DECIMALS: Int = 0
-
-    // A directory for Notary to store Corda participant key pairs for sining Solana transactions,
+    // A directory for Notary to store Corda participant key pairs for signing Solana transactions,
     // intentionally these are located in a different directory than Corda Notary Program key pair
     @TempDir
-    protected lateinit var custodiedKeysDir: Path
+    private lateinit var custodiedKeysDir: Path
 
     @TempDir
-    protected lateinit var otherDir: Path
+    private lateinit var otherDir: Path
 
-    protected lateinit var bridgeAuthoritySigner: FileSigner
-    protected lateinit var shareholderWallet: FileSigner
-    protected lateinit var otherShareholderWallet: FileSigner
-    protected lateinit var redemptionWalletForShareholder: FileSigner
-    protected lateinit var redemptionWalletForOtherShareholder: FileSigner
-    protected lateinit var mintAuthoritySigner: FileSigner
-    protected lateinit var tokenMint: PublicKey
-    protected lateinit var tokenMint2: PublicKey
-
-    protected lateinit var shareholderNode: NodeHandle
-    protected lateinit var otherShareholderNode: NodeHandle
-    protected lateinit var bridgeAuthorityNode: NodeHandle
-
+    fun getSolanaNotaryConfig(solanaNotarySigner: FileSigner) = mapOf<String, Any>(
+        "notary" to mapOf(
+            "validating" to false,
+            "solana" to mapOf(
+                "rpcUrl" to solanaRpcUrl,
+                "websocketUrl" to solanaWebsocketUrl,
+                "notaryKeypairFile" to "${solanaNotarySigner.file}",
+                "custodiedKeysDir" to "$custodiedKeysDir"
+            )
+        )
+    )
     @BeforeEach
     fun setup(validator: SolanaTestValidator) {
         this.validator = validator
         solanaClient = validator.client()
         tokenManagement = validator.tokens()
         accountManagement = validator.accounts()
-        setupAccounts()
-    }
+        solanaRpcUrl = validator.rpcUrl().toString()
+        solanaWebsocketUrl = validator.websocketUrl().toString()
 
-    open fun setupAccounts() {
         bridgeAuthoritySigner = FileSigner.random(custodiedKeysDir)
         redemptionWalletForShareholder = FileSigner.random(custodiedKeysDir)
         redemptionWalletForOtherShareholder = FileSigner.random(custodiedKeysDir)
@@ -136,14 +73,18 @@ open class BridgingTokenDriverTest {
         log.info("  Airdrop for: ${mintAuthoritySigner.publicKey().toBase58()}")
         accountManagement.airdropSol(mintAuthoritySigner.publicKey(), 1)
 
+        // Stockpaydividend doesn't use fractionDigits, in order to maintain 1:1 conversion with Solana token,
+        // Solana token will not have fraction digits as well
+        val tokenDecimals: Int = 0
+
         tokenMint =
-            tokenManagement.createToken(mintAuthoritySigner, TokenProgram.TOKEN_2022, decimals = TOKEN_DECIMALS)
+            tokenManagement.createToken(mintAuthoritySigner, TokenProgram.TOKEN_2022, decimals = tokenDecimals)
         //tokenMint2 not in use in the test, it's a showcase that can be multiple asset mapping
         tokenMint2 =
-            tokenManagement.createToken(mintAuthoritySigner, TokenProgram.TOKEN_2022, decimals = TOKEN_DECIMALS)
+            tokenManagement.createToken(mintAuthoritySigner, TokenProgram.TOKEN_2022, decimals = tokenDecimals)
 
-        log.info("  Shareholder Token Account: ${shareholderWallet.deriveATA().toBase58()}")
-        log.info("  Other Shareholder Token Account: ${otherShareholderWallet.deriveATA().toBase58()}")
+        log.info("  Shareholder Token Account: ${shareholderWallet.toATA().toBase58()}")
+        log.info("  Other Shareholder Token Account: ${otherShareholderWallet.toATA().toBase58()}")
 
         accountManagement.airdropSol(bridgeAuthoritySigner.publicKey(), 1)
         accountManagement.airdropSol(shareholderWallet.publicKey(), 1)
@@ -168,171 +109,8 @@ open class BridgingTokenDriverTest {
         )
     }
 
-    open fun getSolanaNotaryConfig(solanaNotarySigner: FileSigner) = mapOf<String, Any>(
-        "notary" to mapOf(
-            "validating" to false,
-            "solana" to mapOf(
-                "rpcUrl" to  "${validator.rpcUrl()}",
-                "websocketUrl" to "${validator.websocketUrl()}",
-                "notaryKeypairFile" to "${solanaNotarySigner.file}",
-                "custodiedKeysDir" to "$custodiedKeysDir"
-            )
-        )
-    )
-
-    fun TestCordapp.withBridgeAuthorityConfig(
-        cordaTokenTypeIdentifier1: String,
-        cordaTokenTypeIdentifier2: String
-    ): TestCordapp = this.withConfig(
-        mapOf(
-            "participants" to mapOf(
-                "$shareholderName" to shareholderWallet.publicKey().toBase58(),
-                "$otherShareholderName" to otherShareholderWallet.publicKey().toBase58(),
-            ),
-            "redemptionWalletAccountToHolder" to mapOf(
-                redemptionWalletForShareholder.publicKey().toBase58() to "$shareholderName",
-                redemptionWalletForOtherShareholder.publicKey().toBase58() to "$otherShareholderName",
-            ),
-            "mintsWithAuthorities" to mapOf(
-                cordaTokenTypeIdentifier1 to
-                        mapOf(
-                            "tokenMint" to tokenMint.toBase58(),
-                            "mintAuthority" to mintAuthoritySigner.publicKey().toBase58()
-                        ),
-                cordaTokenTypeIdentifier2 to
-                        mapOf(
-                            "tokenMint" to tokenMint2.toBase58(),
-                            "mintAuthority" to mintAuthoritySigner.publicKey().toBase58()
-                        )
-            ),
-            "lockingIdentityLabel" to UUID.randomUUID().toString(),
-            "solanaNotaryName" to "$solanaNotaryName",
-            "generalNotaryName" to "$generalNotaryName",
-            "solanaRpcUrl" to "${validator.rpcUrl()}",
-            "solanaWsUrl" to "${validator.websocketUrl()}",
-            "bridgeAuthorityWalletFile" to bridgeAuthoritySigner.file.toString()
-        )
-    )
-
-    fun DriverDSL.runtimeSetup() {
-        val wayneCoNode = startNode(
-            NodeParameters(
-                CordaX500Name("WayneCo", "SF", "US"),
-                rpcUsers
-            )
-        ).getOrThrow()
-
-        shareholderNode = startNode(
-            NodeParameters(
-                shareholderName,
-                rpcUsers,
-                rpcAddress = NetworkHostAndPort("localhost", 10345)
-            )
-        ).getOrThrow()
-
-        otherShareholderNode = startNode(
-            NodeParameters(
-                otherShareholderName,
-                rpcUsers,
-                rpcAddress = NetworkHostAndPort("localhost", 10349)
-            )
-        ).getOrThrow()
-
-        val bankNode = startNode(
-            NodeParameters(
-                CordaX500Name("Bank", "Washington DC", "US"),
-                rpcUsers
-            )
-        ).getOrThrow()
-
-        startNode(
-            NodeParameters(
-                CordaX500Name("Observer", "Washington DC", "US"),
-                rpcUsers
-            )
-        ).getOrThrow()
-
-        bankNode.rpc.startFlow(
-            ::IssueMoney,
-            "USD",
-            500000L,
-            wayneCoNode.nodeInfo.singleIdentity()
-        ).returnValue.get()
-
-        wayneCoNode.rpc.startFlow(
-            ::CreateAndIssueStock,
-            "AAPL",
-            "Apple",
-            "USD",
-            BigDecimal.TEN,
-            1000,
-            notaryHandles.single { it.identity.name == generalNotaryName }.identity
-        ).returnValue.get()
-        val appleCordaTokenTypeIdentifier = wayneCoNode.getCordaTokenTypeIdentifier("AAPL")
-
-        wayneCoNode.rpc.startFlow(
-            ::CreateAndIssueStock,
-            "MSFT",
-            "Microsoft",
-            "USD",
-            BigDecimal.TEN,
-            2000,
-            notaryHandles.single { it.identity.name == generalNotaryName }.identity
-        ).returnValue.get()
-        val msftCordaTokenTypeIdentifier = wayneCoNode.getCordaTokenTypeIdentifier("MSFT")
-
-        bridgeAuthorityNode = startNode(
-            NodeParameters(
-                providedName = bridgeAuthority,
-                rpcUsers = rpcUsers,
-                additionalCordapps = listOf(
-                    bridgingContracts,
-                    bridgingWorkflowsWithoutConfig
-                        .withBridgeAuthorityConfig(
-                            appleCordaTokenTypeIdentifier,
-                            msftCordaTokenTypeIdentifier
-                        )
-                )
-            )
-        ).getOrThrow()
-
-        log.info("\nCorda APPL stock ($appleCordaTokenTypeIdentifier) is mapped to Solana tokenMint: ${tokenMint.toBase58()}")
-        log.info("\nCorda MSFT stock ($msftCordaTokenTypeIdentifier) is mapped to Solana tokenMint: ${tokenMint2.toBase58()}")
-
-        wayneCoNode.rpc.startFlow(
-            ::MoveStock,
-            "AAPL",
-            100,
-            shareholderNode.nodeInfo.singleIdentity()
-        ).returnValue.get()
-
-        wayneCoNode.rpc.startFlow(
-            ::MoveStock,
-            "MSFT",
-            10,
-            shareholderNode.nodeInfo.singleIdentity()
-        ).returnValue.get()
-
-        val result = shareholderNode.rpc.startFlow(
-            ::GetStockBalance,
-            "AAPL"
-        ).returnValue.get()!!.trimIndent()
-        assertEquals(
-            "You currently have 100 AAPL stocks",
-            result,
-            "Shareholder received stocks on Corda network"
-        )
-        log.info("\nState before bridging:")
-        log.info("  Shareholder Corda balance: ${shareholderNode.cordaBalance()}")
-        log.info("  Other ShareholderNode Corda balance: ${otherShareholderNode.cordaBalance()}")
-        log.info("  Bridge Authority Corda balance: ${bridgeAuthorityNode.cordaBalance()}")
-        log.info("\nSolana state before bridging:")
-        log.info("  Shareholder: ${shareholderWallet.solanaBalance()}")
-        log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
-    }
-
     @Test
-    open fun `briding token test`(@Notary notaryKey: FileSigner) = driver(
+    open fun `local net bridge token test`(@Notary notarySigner: FileSigner) = driver(
         DriverParameters(
             isDebug = false,
             inMemoryDB = false,
@@ -341,7 +119,7 @@ open class BridgingTokenDriverTest {
             networkParameters = testNetworkParameters(minimumPlatformVersion = 160).copy(notaries = emptyList()),
             notarySpecs = listOf(
                 NotarySpec(generalNotaryName, validating = false, startInProcess = false),
-                NotarySpec(solanaNotaryName, getSolanaNotaryConfig(notaryKey), startInProcess = false)
+                NotarySpec(solanaNotaryName, getSolanaNotaryConfig(notarySigner), startInProcess = false)
             ),
             waitForAllNodesToFinish = false
         )
@@ -349,160 +127,6 @@ open class BridgingTokenDriverTest {
         log.info("\nStarting bridging test using local Solana validator...")
         runtimeSetup()
         test()
-
         log.info("\nBridging test is completed.")
     }
-
-    fun test() {
-        shareholderNode.rpc.startFlow(
-            ::MoveStock,
-            "AAPL",
-            90,
-            bridgeAuthorityNode.nodeInfo.singleIdentity()
-        ).returnValue.get()
-        eventually(duration = 10.seconds) {
-            assertNotNull(
-                solanaClient.getAccountInfo(shareholderWallet.deriveATA()),
-                "ATA should be created",
-            )
-        }
-        eventually(duration = 10.seconds) {
-            val balance = solanaClient.getSolanaTokenBalance(shareholderWallet.deriveATA())
-            val bridgedAmount = BigDecimal(90)
-            assertEquals(
-                bridgedAmount,
-                balance
-            ) {
-                "Shareholder bridged $bridgedAmount tokens to Solana"
-            }
-        }
-        log.info("\nCorda state after bridging:")
-        log.info("  Shareholder: ${shareholderNode.cordaBalance()}")
-        log.info("  Other ShareholderNode: ${otherShareholderNode.cordaBalance()}")
-        log.info("  Bridge Authority: ${bridgeAuthorityNode.cordaBalance()}")
-        log.info("\nSolana state after bridging:")
-        log.info("  Shareholder: ${shareholderWallet.solanaBalance()}")
-        log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
-
-        tokenManagement.transfer(
-            shareholderWallet,
-            shareholderWallet.deriveATA(),
-            otherShareholderWallet.deriveATA(),
-            50
-        )
-
-        log.info("\nSolana state after on-chain transfer of 50 from Shareholder to Other Shareholder:")
-        log.info("  Shareholder: ${shareholderWallet.solanaBalance()}")
-        log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
-
-        tokenManagement.transfer(
-            otherShareholderWallet,
-            otherShareholderWallet.deriveATA(),
-            redemptionWalletForOtherShareholder.deriveATA(),
-            25
-        )
-
-        eventually(duration = 1.seconds) {
-            val balance = solanaClient.getSolanaTokenBalance(otherShareholderWallet.deriveATA())
-            val bridgedAmount = BigDecimal(25)
-            assertEquals(
-                bridgedAmount,
-                balance
-            ) {
-                "Other shareholder has sent $bridgedAmount tokens on Solana to redeem on Corda"
-            }
-        }
-
-        eventually(duration = 20.seconds, waitBefore = 10.seconds, waitBetween = 1.seconds) {
-            val result2 = otherShareholderNode.rpc.startFlow(
-                ::GetStockBalance,
-                "AAPL"
-            ).returnValue.get()!!.trimIndent()
-
-            assertEquals(
-                "You currently have 25 AAPL stocks",
-                result2,
-                "Other Shareholder received stocks on Corda that he had redeemed on Solana"
-            )
-        }
-        log.info("\nSolana state before redemptions:")
-        log.info("  Shareholder: ${shareholderWallet.solanaBalance()}")
-        log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
-
-        tokenManagement.transfer(
-            shareholderWallet,
-            shareholderWallet.deriveATA(),
-            redemptionWalletForShareholder.deriveATA(),
-            20
-        )
-
-        eventually(duration = 20.seconds, waitBefore = 10.seconds, waitBetween = 1.seconds) {
-            val result2 = shareholderNode.rpc.startFlow(
-                ::GetStockBalance,
-                "AAPL"
-            ).returnValue.get()!!.trimIndent()
-
-            assertEquals(
-                "You currently have 30 AAPL stocks",
-                result2,
-                "Other Shareholder received stocks on Corda that he had redeemed on Solana"
-            )
-        }
-        log.info("\nCorda state after redemptions:")
-        log.info("  Shareholder: ${shareholderNode.cordaBalance()}")
-        log.info("  Other ShareholderNode: ${otherShareholderNode.cordaBalance()}")
-        log.info("  Bridge Authority: ${bridgeAuthorityNode.cordaBalance()}")
-        log.info("\nSolana state after redemptions:")
-        log.info("  Shareholder: ${shareholderWallet.solanaBalance()}")
-        log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
-    }
-
-    /** Driven ATA for Token2022 and token mint for Apple */
-    fun PublicKey.deriveATA(): PublicKey {
-        val ataProgram = SolanaAccounts.MAIN_NET.associatedTokenAccountProgram()
-        val pda = PublicKey.findProgramAddress(
-            listOf(
-                this.toByteArray(),
-                Token2022.PROGRAM_ID.toPublicKey().toByteArray(),
-                tokenMint.toByteArray()
-            ),
-            ataProgram
-        )
-        return pda.publicKey()
-    }
-
-    /** Driven ATA for Token2022 and token mint for Apple */
-    fun Signer.deriveATA(): PublicKey = this.publicKey().deriveATA()
-
-    fun NodeHandle.cordaBalance(): String = try {
-        this.rpc.startFlow(
-            ::GetStockBalance,
-            "AAPL"
-        ).returnValue.get()!!.trimIndent()
-    } catch (_: ExecutionException) {
-        "No AAPL shares"
-    }
-
-    fun Signer.solanaBalance(): String =
-        if (solanaClient.getAccountInfo(this.deriveATA()) != null) {
-            "${solanaClient.getSolanaTokenBalance(this.deriveATA())} coins"
-        } else {
-            "no stablecoin account"
-        }
-
-    fun NodeHandle.getCordaTokenTypeIdentifier(symbol: String): String {
-        return this.rpc.vaultQuery(StockState::class.java).states.single {
-            it.state.data.symbol == symbol
-        }.state.data.linearId.toString()
-    }
 }
-
-fun SolanaClient.getAccountInfo(tokenAccount: PublicKey): Token2022Account? {
-    val raw = this.call(SolanaRpcClient::getAccountInfo, tokenAccount)
-    return if (raw?.data != null) Token2022Account.read(raw.pubKey, raw.data) else null
-}
-
-fun SolanaClient.getSolanaTokenBalance(tokenAccount: PublicKey): BigDecimal =
-    this.call(SolanaRpcClient::getTokenAccountBalance, tokenAccount).amount.toBigDecimal()
-
-fun Pubkey.toPublicKey(): PublicKey = PublicKey.createPubKey(bytes)

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/LocalNetBridgeTokenTest.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/LocalNetBridgeTokenTest.kt
@@ -83,8 +83,8 @@ open class LocalNetBridgeTokenTest : TestBase() {
         tokenMint2 =
             tokenManagement.createToken(mintAuthoritySigner, TokenProgram.TOKEN_2022, decimals = tokenDecimals)
 
-        log.info("  Shareholder Token Account: ${shareholderWallet.toATA().toBase58()}")
-        log.info("  Other Shareholder Token Account: ${otherShareholderWallet.toATA().toBase58()}")
+        log.info("  Shareholder Token Account: ${shareholderWallet.deriveATA().toBase58()}")
+        log.info("  Other Shareholder Token Account: ${otherShareholderWallet.deriveATA().toBase58()}")
 
         accountManagement.airdropSol(bridgeAuthoritySigner.publicKey(), 1)
         accountManagement.airdropSol(shareholderWallet.publicKey(), 1)

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/LocalNetBridgeTokenTest.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/LocalNetBridgeTokenTest.kt
@@ -6,17 +6,17 @@ import net.corda.core.solana.Pubkey
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
-import net.corda.node.utilities.solana.AccountManagement
-import net.corda.node.utilities.solana.TokenManagement
-import net.corda.node.utilities.solana.TokenProgram
+import com.r3.corda.lib.solana.core.AccountManagement
+import com.r3.corda.lib.solana.core.FileSigner
+import com.r3.corda.lib.solana.core.SolanaClient
+import com.r3.corda.lib.solana.core.cordautils.Token2022
+import com.r3.corda.lib.solana.core.tokens.TokenManagement
+import com.r3.corda.lib.solana.core.tokens.TokenProgram
 import net.corda.samples.stockpaydividend.flows.CreateAndIssueStock
 import net.corda.samples.stockpaydividend.flows.GetStockBalance
 import net.corda.samples.stockpaydividend.flows.IssueMoney
 import net.corda.samples.stockpaydividend.flows.MoveStock
 import net.corda.samples.stockpaydividend.states.StockState
-import net.corda.solana.notary.common.FileSigner
-import net.corda.solana.notary.common.SolanaClient
-import net.corda.solana.sdk.Token2022
 import net.corda.testing.common.internal.eventually
 import net.corda.testing.common.internal.testNetworkParameters
 import net.corda.testing.core.singleIdentity
@@ -28,8 +28,6 @@ import net.corda.testing.driver.driver
 import net.corda.testing.node.NotarySpec
 import net.corda.testing.node.TestCordapp
 import net.corda.testing.node.User
-import net.corda.testing.solana.SolanaTestValidator
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -39,36 +37,31 @@ import org.slf4j.LoggerFactory
 import software.sava.core.accounts.PublicKey
 import software.sava.core.accounts.Signer
 import software.sava.core.accounts.SolanaAccounts
-import software.sava.core.accounts.meta.AccountMeta
 import software.sava.core.accounts.token.Token2022Account
-import software.sava.core.tx.Instruction
 import software.sava.rpc.json.http.client.SolanaRpcClient
 import java.math.BigDecimal
 import java.nio.file.Path
 import java.util.UUID
 import java.util.concurrent.ExecutionException
+import com.r3.corda.lib.solana.testing.SolanaTestValidator
+import net.corda.solana.notary.testing.Notary
+import net.corda.solana.notary.testing.SolanaNotaryExtension
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(SolanaNotaryExtension::class)
 open class BridgingTokenDriverTest {
 
     protected val log = LoggerFactory.getLogger(BridgingTokenDriverTest::class.java)
     private lateinit var validator: SolanaTestValidator
     protected lateinit var tokenManagement: TokenManagement
     protected lateinit var accountManagement: AccountManagement
-    protected lateinit var solanaNotarySigner: FileSigner
     protected lateinit var solanaClient: SolanaClient
-
-    // A directory with Corda Notary key pair for singing Corda Program on Solana
-    @TempDir
-    private lateinit var notaryKeyDir: Path
 
     protected val solanaNotaryName = CordaX500Name("Solana Notary", "London", "GB")
     protected val generalNotaryName = CordaX500Name("Notary", "London", "GB")
     private val bridgeAuthority = CordaX500Name("Bridge Authority", "New York", "US")
     private val shareholderName = CordaX500Name("Shareholder", "New York", "US")
     private val otherShareholderName = CordaX500Name("Other Shareholder", "Frankfurt", "DE")
-
-    protected open val solanaRpcUrl = SolanaTestValidator.RPC_URL
-    protected open val solanaWssUrl = SolanaTestValidator.WS_URL
 
     protected val cordappsForAllNodes =
         listOf(
@@ -112,19 +105,12 @@ open class BridgingTokenDriverTest {
     protected lateinit var bridgeAuthorityNode: NodeHandle
 
     @BeforeEach
-    fun setup() {
-        startTestValidator()
+    fun setup(validator: SolanaTestValidator) {
+        this.validator = validator
+        solanaClient = validator.client()
+        tokenManagement = validator.tokens()
+        accountManagement = validator.accounts()
         setupAccounts()
-    }
-
-    open fun startTestValidator() {
-        solanaNotarySigner = FileSigner.random(notaryKeyDir)
-        validator = SolanaTestValidator()
-        validator.startAndWait()
-        validator.defaultNotaryProgramSetup(solanaNotarySigner.publicKey())
-        solanaClient = validator.client
-        tokenManagement = TokenManagement(validator.client)
-        accountManagement = AccountManagement(validator.client)
     }
 
     open fun setupAccounts() {
@@ -165,37 +151,29 @@ open class BridgingTokenDriverTest {
         accountManagement.airdropSol(redemptionWalletForShareholder.publicKey(), 1)
         accountManagement.airdropSol(redemptionWalletForOtherShareholder.publicKey(), 1)
 
-        tokenManagement.createAta(
+        tokenManagement.createAssociatedTokenAccount(
             mintAuthoritySigner,
+            tokenMint,
             otherShareholderWallet.publicKey(),
-            tokenMint,
-            Token2022.PROGRAM_ID.toPublicKey()
         )
-        tokenManagement.createAta(
+        tokenManagement.createAssociatedTokenAccount(
             mintAuthoritySigner,
+            tokenMint,
             redemptionWalletForOtherShareholder.publicKey(),
-            tokenMint,
-            Token2022.PROGRAM_ID.toPublicKey()
         )
-        tokenManagement.createAta(
+        tokenManagement.createAssociatedTokenAccount(
             mintAuthoritySigner,
-            redemptionWalletForShareholder.publicKey(),
             tokenMint,
-            Token2022.PROGRAM_ID.toPublicKey()
+            redemptionWalletForShareholder.publicKey(),
         )
     }
 
-    @AfterEach
-    open fun stopTestValidator() {
-        validator.close()
-    }
-
-    open fun getSolanaNotaryConfig() = mapOf<String, Any>(
+    open fun getSolanaNotaryConfig(solanaNotarySigner: FileSigner) = mapOf<String, Any>(
         "notary" to mapOf(
             "validating" to false,
             "solana" to mapOf(
-                "rpcUrl" to solanaRpcUrl,
-                "websocketUrl" to solanaWssUrl,
+                "rpcUrl" to  "${validator.rpcUrl()}",
+                "websocketUrl" to "${validator.websocketUrl()}",
                 "notaryKeypairFile" to "${solanaNotarySigner.file}",
                 "custodiedKeysDir" to "$custodiedKeysDir"
             )
@@ -230,8 +208,8 @@ open class BridgingTokenDriverTest {
             "lockingIdentityLabel" to UUID.randomUUID().toString(),
             "solanaNotaryName" to "$solanaNotaryName",
             "generalNotaryName" to "$generalNotaryName",
-            "solanaWsUrl" to solanaWssUrl,
-            "solanaRpcUrl" to solanaRpcUrl,
+            "solanaRpcUrl" to "${validator.rpcUrl()}",
+            "solanaWsUrl" to "${validator.websocketUrl()}",
             "bridgeAuthorityWalletFile" to bridgeAuthoritySigner.file.toString()
         )
     )
@@ -354,7 +332,7 @@ open class BridgingTokenDriverTest {
     }
 
     @Test
-    open fun `briding token test`() = driver(
+    open fun `briding token test`(@Notary notaryKey: FileSigner) = driver(
         DriverParameters(
             isDebug = false,
             inMemoryDB = false,
@@ -363,7 +341,7 @@ open class BridgingTokenDriverTest {
             networkParameters = testNetworkParameters(minimumPlatformVersion = 160).copy(notaries = emptyList()),
             notarySpecs = listOf(
                 NotarySpec(generalNotaryName, validating = false, startInProcess = false),
-                NotarySpec(solanaNotaryName, getSolanaNotaryConfig(), startInProcess = false)
+                NotarySpec(solanaNotaryName, getSolanaNotaryConfig(notaryKey), startInProcess = false)
             ),
             waitForAllNodesToFinish = false
         )
@@ -516,37 +494,6 @@ open class BridgingTokenDriverTest {
         return this.rpc.vaultQuery(StockState::class.java).states.single {
             it.state.data.symbol == symbol
         }.state.data.linearId.toString()
-    }
-
-    //TODO move the method to TokenManagement class
-    fun TokenManagement.createAta(
-        payer: Signer,
-        owner: PublicKey,
-        mint: PublicKey,
-        tokenProgram: PublicKey
-    ): PublicKey {
-        val solana = SolanaAccounts.MAIN_NET
-        val ata = owner.deriveATA()
-        val createIdempotentIx = Instruction.createInstruction(
-            solana.associatedTokenAccountProgram(),
-            listOf(
-                AccountMeta.createFeePayer(payer.publicKey()),
-                AccountMeta.createWrite(ata),
-                AccountMeta.createRead(owner),
-                AccountMeta.createRead(mint),
-                AccountMeta.createRead(solana.systemProgram()),
-                AccountMeta.createRead(tokenProgram)
-            ),
-            byteArrayOf(1)
-        )
-        /*validator.client*/solanaClient.sendAndConfirm(
-            {
-                it.createTransaction(listOf(createIdempotentIx))
-            },
-            payer,
-            listOf()
-        )
-        return ata
     }
 }
 

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/TestBase.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/TestBase.kt
@@ -1,0 +1,386 @@
+package net.corda.samples.solana.bridge.token
+
+import com.r3.corda.lib.solana.core.AccountManagement
+import com.r3.corda.lib.solana.core.FileSigner
+import com.r3.corda.lib.solana.core.SolanaClient
+import com.r3.corda.lib.solana.core.cordautils.Token2022
+import com.r3.corda.lib.solana.core.tokens.TokenManagement
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.messaging.startFlow
+import net.corda.core.solana.Pubkey
+import net.corda.core.utilities.NetworkHostAndPort
+import net.corda.core.utilities.getOrThrow
+import net.corda.core.utilities.seconds
+import net.corda.samples.stockpaydividend.flows.CreateAndIssueStock
+import net.corda.samples.stockpaydividend.flows.GetStockBalance
+import net.corda.samples.stockpaydividend.flows.IssueMoney
+import net.corda.samples.stockpaydividend.flows.MoveStock
+import net.corda.samples.stockpaydividend.states.StockState
+import net.corda.testing.common.internal.eventually
+import net.corda.testing.core.singleIdentity
+import net.corda.testing.driver.DriverDSL
+import net.corda.testing.driver.NodeHandle
+import net.corda.testing.driver.NodeParameters
+import net.corda.testing.node.TestCordapp
+import net.corda.testing.node.User
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertNotNull
+import org.slf4j.LoggerFactory
+import software.sava.core.accounts.PublicKey
+import software.sava.core.accounts.Signer
+import software.sava.core.accounts.SolanaAccounts
+import software.sava.core.accounts.token.Token2022Account
+import software.sava.rpc.json.http.client.SolanaRpcClient
+import java.math.BigDecimal
+import java.util.UUID
+import java.util.concurrent.ExecutionException
+import kotlin.text.trimIndent
+
+open class TestBase {
+
+    private val log = LoggerFactory.getLogger(TestBase::class.java)
+
+    protected lateinit var tokenManagement: TokenManagement
+    protected lateinit var accountManagement: AccountManagement
+    protected lateinit var solanaClient: SolanaClient
+    protected open lateinit var solanaRpcUrl : String
+    protected open lateinit var solanaWebsocketUrl : String
+
+    protected val solanaNotaryName = CordaX500Name("Solana Notary", "London", "GB")
+    protected val generalNotaryName = CordaX500Name("Notary", "London", "GB")
+    protected val bridgeAuthority = CordaX500Name("Bridge Authority", "New York", "US")
+    protected val shareholderName = CordaX500Name("Shareholder", "New York", "US")
+    protected val otherShareholderName = CordaX500Name("Other Shareholder", "Frankfurt", "DE")
+
+    protected val cordappsForAllNodes =
+        listOf(
+            TestCordapp.findCordapp("com.r3.corda.lib.tokens.contracts"),
+            TestCordapp.findCordapp("com.r3.corda.lib.tokens.workflows"),
+            TestCordapp.findCordapp("net.corda.samples.stockpaydividend.states"),
+            TestCordapp.findCordapp("net.corda.samples.stockpaydividend.contracts"),
+            TestCordapp.findCordapp("net.corda.samples.stockpaydividend.flows").withConfig(
+                mapOf("notary" to "O=Notary,L=London,C=GB") // Solana Notary is an additional notary in the Corda network in this sample
+                // set preferred notary for flows that don't receive a notary as parameters (e.g. flows in Corda Tokens SDK)
+            )
+        )
+    val bridgingContracts = TestCordapp.findCordapp("com.r3.corda.lib.solana.bridging.token.contracts")
+    var bridgingWorkflowsWithoutConfig = TestCordapp.findCordapp("com.r3.corda.lib.solana.bridging.token.flows")
+
+    val rpcUsers = listOf(User("user1", "test", permissions = setOf("ALL")))
+
+    protected lateinit var bridgeAuthoritySigner: FileSigner
+    protected lateinit var shareholderWallet: FileSigner
+    protected lateinit var otherShareholderWallet: FileSigner
+    protected lateinit var redemptionWalletForShareholder: FileSigner
+    protected lateinit var redemptionWalletForOtherShareholder: FileSigner
+    protected lateinit var mintAuthoritySigner: FileSigner
+    protected lateinit var tokenMint: PublicKey
+    protected lateinit var tokenMint2: PublicKey
+
+    protected lateinit var shareholderNode: NodeHandle
+    protected lateinit var otherShareholderNode: NodeHandle
+    protected lateinit var bridgeAuthorityNode: NodeHandle
+
+    fun TestCordapp.withBridgeAuthorityConfig(
+        cordaTokenTypeIdentifier1: String,
+        cordaTokenTypeIdentifier2: String,
+    ): TestCordapp = this.withConfig(
+        mapOf(
+            "participants" to mapOf(
+                "$shareholderName" to shareholderWallet.publicKey().toBase58(),
+                "$otherShareholderName" to otherShareholderWallet.publicKey().toBase58(),
+            ),
+            "redemptionWalletAccountToHolder" to mapOf(
+                redemptionWalletForShareholder.publicKey().toBase58() to "$shareholderName",
+                redemptionWalletForOtherShareholder.publicKey().toBase58() to "$otherShareholderName",
+            ),
+            "mintsWithAuthorities" to mapOf(
+                cordaTokenTypeIdentifier1 to
+                        mapOf(
+                            "tokenMint" to tokenMint.toBase58(),
+                            "mintAuthority" to mintAuthoritySigner.publicKey().toBase58()
+                        ),
+                cordaTokenTypeIdentifier2 to
+                        mapOf(
+                            "tokenMint" to tokenMint2.toBase58(),
+                            "mintAuthority" to mintAuthoritySigner.publicKey().toBase58()
+                        )
+            ),
+            "lockingIdentityLabel" to UUID.randomUUID().toString(),
+            "solanaNotaryName" to "$solanaNotaryName",
+            "generalNotaryName" to "$generalNotaryName",
+            "solanaRpcUrl" to solanaRpcUrl,
+            "solanaWsUrl" to solanaWebsocketUrl,
+            "bridgeAuthorityWalletFile" to bridgeAuthoritySigner.file.toString()
+        )
+    )
+
+    fun DriverDSL.runtimeSetup() {
+        val wayneCoNode = startNode(
+            NodeParameters(
+                CordaX500Name("WayneCo", "SF", "US"),
+                rpcUsers
+            )
+        ).getOrThrow()
+
+        shareholderNode = startNode(
+            NodeParameters(
+                shareholderName,
+                rpcUsers,
+                rpcAddress = NetworkHostAndPort("localhost", 10345)
+            )
+        ).getOrThrow()
+
+        otherShareholderNode = startNode(
+            NodeParameters(
+                otherShareholderName,
+                rpcUsers,
+                rpcAddress = NetworkHostAndPort("localhost", 10349)
+            )
+        ).getOrThrow()
+
+        val bankNode = startNode(
+            NodeParameters(
+                CordaX500Name("Bank", "Washington DC", "US"),
+                rpcUsers
+            )
+        ).getOrThrow()
+
+        startNode(
+            NodeParameters(
+                CordaX500Name("Observer", "Washington DC", "US"),
+                rpcUsers
+            )
+        ).getOrThrow()
+
+        bankNode.rpc.startFlow(
+            ::IssueMoney,
+            "USD",
+            500000L,
+            wayneCoNode.nodeInfo.singleIdentity()
+        ).returnValue.get()
+
+        wayneCoNode.rpc.startFlow(
+            ::CreateAndIssueStock,
+            "AAPL",
+            "Apple",
+            "USD",
+            BigDecimal.TEN,
+            1000,
+            notaryHandles.single { it.identity.name == generalNotaryName }.identity
+        ).returnValue.get()
+        val appleCordaTokenTypeIdentifier = wayneCoNode.getCordaTokenTypeIdentifier("AAPL")
+
+        wayneCoNode.rpc.startFlow(
+            ::CreateAndIssueStock,
+            "MSFT",
+            "Microsoft",
+            "USD",
+            BigDecimal.TEN,
+            2000,
+            notaryHandles.single { it.identity.name == generalNotaryName }.identity
+        ).returnValue.get()
+        val msftCordaTokenTypeIdentifier = wayneCoNode.getCordaTokenTypeIdentifier("MSFT")
+
+        bridgeAuthorityNode = startNode(
+            NodeParameters(
+                providedName = bridgeAuthority,
+                rpcUsers = rpcUsers,
+                additionalCordapps = listOf(
+                    bridgingContracts,
+                    bridgingWorkflowsWithoutConfig
+                        .withBridgeAuthorityConfig(
+                            appleCordaTokenTypeIdentifier,
+                            msftCordaTokenTypeIdentifier
+                        )
+                )
+            )
+        ).getOrThrow()
+
+        log.info("\nCorda APPL stock ($appleCordaTokenTypeIdentifier) is mapped to Solana tokenMint: ${tokenMint.toBase58()}")
+        log.info("\nCorda MSFT stock ($msftCordaTokenTypeIdentifier) is mapped to Solana tokenMint: ${tokenMint2.toBase58()}")
+
+        wayneCoNode.rpc.startFlow(
+            ::MoveStock,
+            "AAPL",
+            100,
+            shareholderNode.nodeInfo.singleIdentity()
+        ).returnValue.get()
+
+        wayneCoNode.rpc.startFlow(
+            ::MoveStock,
+            "MSFT",
+            10,
+            shareholderNode.nodeInfo.singleIdentity()
+        ).returnValue.get()
+
+        val result = shareholderNode.rpc.startFlow(
+            ::GetStockBalance,
+            "AAPL"
+        ).returnValue.get()!!.trimIndent()
+        assertEquals(
+            "You currently have 100 AAPL stocks",
+            result,
+            "Shareholder received stocks on Corda network"
+        )
+        log.info("\nState before bridging:")
+        log.info("  Shareholder Corda balance: ${shareholderNode.cordaBalance()}")
+        log.info("  Other ShareholderNode Corda balance: ${otherShareholderNode.cordaBalance()}")
+        log.info("  Bridge Authority Corda balance: ${bridgeAuthorityNode.cordaBalance()}")
+        log.info("\nSolana state before bridging:")
+        log.info("  Shareholder: ${shareholderWallet.solanaBalance()}")
+        log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
+    }
+
+    fun test() {
+        shareholderNode.rpc.startFlow(
+            ::MoveStock,
+            "AAPL",
+            90,
+            bridgeAuthorityNode.nodeInfo.singleIdentity()
+        ).returnValue.get()
+        eventually(duration = 10.seconds) {
+            assertNotNull(
+                solanaClient.getAccountInfo(shareholderWallet.toATA()),
+                "ATA should be created",
+            )
+        }
+        eventually(duration = 10.seconds) {
+            val balance = solanaClient.getSolanaTokenBalance(shareholderWallet.toATA())
+            val bridgedAmount = BigDecimal(90)
+            assertEquals(
+                bridgedAmount,
+                balance
+            ) {
+                "Shareholder bridged $bridgedAmount tokens to Solana"
+            }
+        }
+        log.info("\nCorda state after bridging:")
+        log.info("  Shareholder: ${shareholderNode.cordaBalance()}")
+        log.info("  Other ShareholderNode: ${otherShareholderNode.cordaBalance()}")
+        log.info("  Bridge Authority: ${bridgeAuthorityNode.cordaBalance()}")
+        log.info("\nSolana state after bridging:")
+        log.info("  Shareholder: ${shareholderWallet.solanaBalance()}")
+        log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
+
+        tokenManagement.transfer(
+            shareholderWallet,
+            shareholderWallet.toATA(),
+            otherShareholderWallet.toATA(),
+            50
+        )
+
+        log.info("\nSolana state after on-chain transfer of 50 from Shareholder to Other Shareholder:")
+        log.info("  Shareholder: ${shareholderWallet.solanaBalance()}")
+        log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
+
+        tokenManagement.transfer(
+            otherShareholderWallet,
+            otherShareholderWallet.toATA(),
+            redemptionWalletForOtherShareholder.toATA(),
+            25
+        )
+
+        eventually(duration = 1.seconds) {
+            val balance = solanaClient.getSolanaTokenBalance(otherShareholderWallet.toATA())
+            val bridgedAmount = BigDecimal(25)
+            assertEquals(
+                bridgedAmount,
+                balance
+            ) {
+                "Other shareholder has sent $bridgedAmount tokens on Solana to redeem on Corda"
+            }
+        }
+
+        eventually(duration = 20.seconds, waitBefore = 10.seconds, waitBetween = 1.seconds) {
+            val result2 = otherShareholderNode.rpc.startFlow(
+                ::GetStockBalance,
+                "AAPL"
+            ).returnValue.get()!!.trimIndent()
+
+            assertEquals(
+                "You currently have 25 AAPL stocks",
+                result2,
+                "Other Shareholder received stocks on Corda that he had redeemed on Solana"
+            )
+        }
+        log.info("\nSolana state before redemptions:")
+        log.info("  Shareholder: ${shareholderWallet.solanaBalance()}")
+        log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
+
+        tokenManagement.transfer(
+            shareholderWallet,
+            shareholderWallet.toATA(),
+            redemptionWalletForShareholder.toATA(),
+            20
+        )
+
+        eventually(duration = 20.seconds, waitBefore = 10.seconds, waitBetween = 1.seconds) {
+            val result2 = shareholderNode.rpc.startFlow(
+                ::GetStockBalance,
+                "AAPL"
+            ).returnValue.get()!!.trimIndent()
+
+            assertEquals(
+                "You currently have 30 AAPL stocks",
+                result2,
+                "Other Shareholder received stocks on Corda that he had redeemed on Solana"
+            )
+        }
+        log.info("\nCorda state after redemptions:")
+        log.info("  Shareholder: ${shareholderNode.cordaBalance()}")
+        log.info("  Other ShareholderNode: ${otherShareholderNode.cordaBalance()}")
+        log.info("  Bridge Authority: ${bridgeAuthorityNode.cordaBalance()}")
+        log.info("\nSolana state after redemptions:")
+        log.info("  Shareholder: ${shareholderWallet.solanaBalance()}")
+        log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
+    }
+
+    /** Driven ATA for Token2022 and token mint for Apple */
+    fun PublicKey.toATA(): PublicKey {
+        val ataProgram = SolanaAccounts.MAIN_NET.associatedTokenAccountProgram()
+        val pda = PublicKey.findProgramAddress(
+            listOf(
+                toByteArray(),
+                Token2022.PROGRAM_ID.toPublicKey().toByteArray(),
+                tokenMint.toByteArray()
+            ),
+            ataProgram
+        )
+        return pda.publicKey()
+    }
+
+    /** Driven ATA for Token2022 and token mint for Apple */
+    fun Signer.toATA(): PublicKey = publicKey().toATA()
+
+    fun NodeHandle.cordaBalance(): String = try {
+        rpc.startFlow(
+            ::GetStockBalance,
+            "AAPL"
+        ).returnValue.get()!!.trimIndent()
+    } catch (_: ExecutionException) {
+        "No AAPL shares"
+    }
+
+    fun Signer.solanaBalance(): String =
+        if (solanaClient.getAccountInfo(toATA()) != null) {
+            "${solanaClient.getSolanaTokenBalance(toATA())} coins"
+        } else {
+            "no stablecoin account"
+        }
+
+    fun NodeHandle.getCordaTokenTypeIdentifier(symbol: String) =
+        rpc.vaultQuery(StockState::class.java).states.single {
+            it.state.data.symbol == symbol
+        }.state.data.linearId.toString()
+}
+
+fun SolanaClient.getAccountInfo(tokenAccount: PublicKey): Token2022Account? {
+    val raw = call(SolanaRpcClient::getAccountInfo, tokenAccount)
+    return if (raw?.data != null) Token2022Account.read(raw.pubKey, raw.data) else null
+}
+
+fun SolanaClient.getSolanaTokenBalance(tokenAccount: PublicKey): BigDecimal =
+    call(SolanaRpcClient::getTokenAccountBalance, tokenAccount).amount.toBigDecimal()
+
+fun Pubkey.toPublicKey(): PublicKey = PublicKey.createPubKey(bytes)

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/TestBase.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/TestBase.kt
@@ -241,12 +241,12 @@ open class TestBase {
         ).returnValue.get()
         eventually(duration = 10.seconds) {
             assertNotNull(
-                solanaClient.getAccountInfo(shareholderWallet.toATA()),
+                solanaClient.getAccountInfo(shareholderWallet.deriveATA()),
                 "ATA should be created",
             )
         }
         eventually(duration = 10.seconds) {
-            val balance = solanaClient.getSolanaTokenBalance(shareholderWallet.toATA())
+            val balance = solanaClient.getSolanaTokenBalance(shareholderWallet.deriveATA())
             val bridgedAmount = BigDecimal(90)
             assertEquals(
                 bridgedAmount,
@@ -265,8 +265,8 @@ open class TestBase {
 
         tokenManagement.transfer(
             shareholderWallet,
-            shareholderWallet.toATA(),
-            otherShareholderWallet.toATA(),
+            shareholderWallet.deriveATA(),
+            otherShareholderWallet.deriveATA(),
             50
         )
 
@@ -276,13 +276,13 @@ open class TestBase {
 
         tokenManagement.transfer(
             otherShareholderWallet,
-            otherShareholderWallet.toATA(),
-            redemptionWalletForOtherShareholder.toATA(),
+            otherShareholderWallet.deriveATA(),
+            redemptionWalletForOtherShareholder.deriveATA(),
             25
         )
 
         eventually(duration = 1.seconds) {
-            val balance = solanaClient.getSolanaTokenBalance(otherShareholderWallet.toATA())
+            val balance = solanaClient.getSolanaTokenBalance(otherShareholderWallet.deriveATA())
             val bridgedAmount = BigDecimal(25)
             assertEquals(
                 bridgedAmount,
@@ -310,8 +310,8 @@ open class TestBase {
 
         tokenManagement.transfer(
             shareholderWallet,
-            shareholderWallet.toATA(),
-            redemptionWalletForShareholder.toATA(),
+            shareholderWallet.deriveATA(),
+            redemptionWalletForShareholder.deriveATA(),
             20
         )
 
@@ -337,7 +337,7 @@ open class TestBase {
     }
 
     /** Driven ATA for Token2022 and token mint for Apple */
-    fun PublicKey.toATA(): PublicKey {
+    fun PublicKey.deriveATA(): PublicKey {
         val ataProgram = SolanaAccounts.MAIN_NET.associatedTokenAccountProgram()
         val pda = PublicKey.findProgramAddress(
             listOf(
@@ -351,7 +351,7 @@ open class TestBase {
     }
 
     /** Driven ATA for Token2022 and token mint for Apple */
-    fun Signer.toATA(): PublicKey = publicKey().toATA()
+    fun Signer.deriveATA(): PublicKey = publicKey().deriveATA()
 
     fun NodeHandle.cordaBalance(): String = try {
         rpc.startFlow(
@@ -363,8 +363,8 @@ open class TestBase {
     }
 
     fun Signer.solanaBalance(): String =
-        if (solanaClient.getAccountInfo(toATA()) != null) {
-            "${solanaClient.getSolanaTokenBalance(toATA())} coins"
+        if (solanaClient.getAccountInfo(deriveATA()) != null) {
+            "${solanaClient.getSolanaTokenBalance(deriveATA())} coins"
         } else {
             "no stablecoin account"
         }

--- a/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/TestBase.kt
+++ b/Solana/bridge-token/workflows/src/integrationTest/kotlin/net/corda/samples/solana/bridge/token/TestBase.kt
@@ -29,22 +29,23 @@ import org.slf4j.LoggerFactory
 import software.sava.core.accounts.PublicKey
 import software.sava.core.accounts.Signer
 import software.sava.core.accounts.SolanaAccounts
-import software.sava.core.accounts.token.Token2022Account
 import software.sava.rpc.json.http.client.SolanaRpcClient
 import java.math.BigDecimal
+import java.net.URI
 import java.util.UUID
 import java.util.concurrent.ExecutionException
 import kotlin.text.trimIndent
 
 open class TestBase {
-
-    private val log = LoggerFactory.getLogger(TestBase::class.java)
+    companion object {
+        val log = LoggerFactory.getLogger(TestBase::class.java)
+    }
 
     protected lateinit var tokenManagement: TokenManagement
     protected lateinit var accountManagement: AccountManagement
     protected lateinit var solanaClient: SolanaClient
-    protected open lateinit var solanaRpcUrl : String
-    protected open lateinit var solanaWebsocketUrl : String
+    protected lateinit var solanaRpcUrl : URI
+    protected lateinit var solanaWebsocketUrl : URI
 
     protected val solanaNotaryName = CordaX500Name("Solana Notary", "London", "GB")
     protected val generalNotaryName = CordaX500Name("Notary", "London", "GB")
@@ -63,10 +64,10 @@ open class TestBase {
                 // set preferred notary for flows that don't receive a notary as parameters (e.g. flows in Corda Tokens SDK)
             )
         )
-    val bridgingContracts = TestCordapp.findCordapp("com.r3.corda.lib.solana.bridging.token.contracts")
-    var bridgingWorkflowsWithoutConfig = TestCordapp.findCordapp("com.r3.corda.lib.solana.bridging.token.flows")
+    protected val bridgingContracts = TestCordapp.findCordapp("com.r3.corda.lib.solana.bridging.token.contracts")
+    protected val bridgingWorkflowsWithoutConfig = TestCordapp.findCordapp("com.r3.corda.lib.solana.bridging.token.flows")
 
-    val rpcUsers = listOf(User("user1", "test", permissions = setOf("ALL")))
+    protected val rpcUsers = listOf(User("user1", "test", permissions = setOf("ALL")))
 
     protected lateinit var bridgeAuthoritySigner: FileSigner
     protected lateinit var shareholderWallet: FileSigner
@@ -81,7 +82,7 @@ open class TestBase {
     protected lateinit var otherShareholderNode: NodeHandle
     protected lateinit var bridgeAuthorityNode: NodeHandle
 
-    fun TestCordapp.withBridgeAuthorityConfig(
+    protected fun TestCordapp.withBridgeAuthorityConfig(
         cordaTokenTypeIdentifier1: String,
         cordaTokenTypeIdentifier2: String,
     ): TestCordapp = this.withConfig(
@@ -109,13 +110,13 @@ open class TestBase {
             "lockingIdentityLabel" to UUID.randomUUID().toString(),
             "solanaNotaryName" to "$solanaNotaryName",
             "generalNotaryName" to "$generalNotaryName",
-            "solanaRpcUrl" to solanaRpcUrl,
-            "solanaWsUrl" to solanaWebsocketUrl,
+            "solanaRpcUrl" to "$solanaRpcUrl",
+            "solanaWsUrl" to "$solanaWebsocketUrl",
             "bridgeAuthorityWalletFile" to bridgeAuthoritySigner.file.toString()
         )
     )
 
-    fun DriverDSL.runtimeSetup() {
+    protected fun DriverDSL.runtimeSetup() {
         val wayneCoNode = startNode(
             NodeParameters(
                 CordaX500Name("WayneCo", "SF", "US"),
@@ -232,7 +233,7 @@ open class TestBase {
         log.info("  Other ShareholderNode: ${otherShareholderWallet.solanaBalance()}")
     }
 
-    fun test() {
+    protected fun test() {
         shareholderNode.rpc.startFlow(
             ::MoveStock,
             "AAPL",
@@ -241,7 +242,7 @@ open class TestBase {
         ).returnValue.get()
         eventually(duration = 10.seconds) {
             assertNotNull(
-                solanaClient.getAccountInfo(shareholderWallet.deriveATA()),
+                accountManagement.getAccountInfo(shareholderWallet.deriveATA()),
                 "ATA should be created",
             )
         }
@@ -362,22 +363,17 @@ open class TestBase {
         "No AAPL shares"
     }
 
-    fun Signer.solanaBalance(): String =
-        if (solanaClient.getAccountInfo(deriveATA()) != null) {
+    protected fun Signer.solanaBalance(): String =
+        if (accountManagement.getAccountInfo(deriveATA()) != null) {
             "${solanaClient.getSolanaTokenBalance(deriveATA())} coins"
         } else {
             "no stablecoin account"
         }
 
-    fun NodeHandle.getCordaTokenTypeIdentifier(symbol: String) =
+    protected fun NodeHandle.getCordaTokenTypeIdentifier(symbol: String) =
         rpc.vaultQuery(StockState::class.java).states.single {
             it.state.data.symbol == symbol
         }.state.data.linearId.toString()
-}
-
-fun SolanaClient.getAccountInfo(tokenAccount: PublicKey): Token2022Account? {
-    val raw = call(SolanaRpcClient::getAccountInfo, tokenAccount)
-    return if (raw?.data != null) Token2022Account.read(raw.pubKey, raw.data) else null
 }
 
 fun SolanaClient.getSolanaTokenBalance(tokenAccount: PublicKey): BigDecimal =

--- a/Solana/constants.properties
+++ b/Solana/constants.properties
@@ -1,8 +1,8 @@
 cordaEnterpriseReleaseGroup=com.r3.corda
 cordaOsReleaseGroup=net.corda
-cordaEnterpriseVersion=4.14-20260206.004000-81
-cordaOsVersion=4.14-20260130_101700-d7fa3ea
-cordaSolanaNotaryVersion=0.2.0
+cordaEnterpriseVersion=4.14-RC01
+cordaOsVersion=4.14-RC01
+cordaSolanaNotaryVersion=0.2.3
 cordaTokensVersion=1.3.2
 savaCoreVersion=25.1.2-j17-2
 savaProgramsVersion=25.0.0-j17-1


### PR DESCRIPTION
Common setup and test code moved to new `TestBase`class.  All test inherits from this class. `DevNetBridgeTokenTest` no longer inherits from `LocalNetBridgeTokenTest`,  which allows the latter to use `@ExtendWith(SolanaNotaryExtension::class)` while `DevNetBridgeTokenTest` doesn't start a validator.