### PR TITLE
Update docs for Solana samples - follow-up

### DIFF
--- a/Solana/README.md
+++ b/Solana/README.md
@@ -28,7 +28,7 @@ leg completing without the other.
 
 ## Devnet
 
-The samples can also be run against [Solana devnet](https://solscan.io/account/notary95bwkGXj74HV2CXeCn4CgBzRVv5nmEVfqonVY?cluster=devnet)
+The samples (Bridge Authority out-of-box) can also be run against [Solana devnet](https://solscan.io/account/notary95bwkGXj74HV2CXeCn4CgBzRVv5nmEVfqonVY?cluster=devnet)
 where [`devnet-sample-notary-keypair.json`](devnet-sample-notary-keypair.json) has been provisioned for testing
 purposes.
 

--- a/Solana/README.md
+++ b/Solana/README.md
@@ -28,7 +28,7 @@ leg completing without the other.
 
 ## Devnet
 
-The samples (Bridge Authority out-of-box) can also be run against [Solana devnet](https://solscan.io/account/notary95bwkGXj74HV2CXeCn4CgBzRVv5nmEVfqonVY?cluster=devnet)
+The Bridge Authority sample can also be run against [Solana devnet](https://solscan.io/account/notary95bwkGXj74HV2CXeCn4CgBzRVv5nmEVfqonVY?cluster=devnet)
 where [`devnet-sample-notary-keypair.json`](devnet-sample-notary-keypair.json) has been provisioned for testing
 purposes.
 

--- a/Solana/delivery-vs-payment/README.md
+++ b/Solana/delivery-vs-payment/README.md
@@ -94,6 +94,8 @@ Prerequisite: A buyer owns an amount of stablecoins on Solana.
 | `solanaRpcUrl`        | Solana RPC endpoint (`http://127.0.0.1:8899` for the local validator; `https://api.devnet.solana.com` for devnet)                 |
 | `solanaWebsocketUrl`  | Corresponding WebSocket URL (`ws://127.0.0.1:8900` for the local validator; `wss://api.devnet.solana.com` for devnet)             |
 
+Note: The test `StockDvpDriverTest.kt` can run the Cordapp against local validator only.
+
 ### Notary config
 
 The Solana-specific notary configuration fields (`node.conf`, under `notary.solana`) are documented


### PR DESCRIPTION
Clarification that only the Bridge Authority sample can run against local test validator or Solana devnet out-of-box, while DvP sample runs against local test validator only (the integration test, Cordapp could be run on both).

Follow up of comments add to PR https://github.com/corda/samples-kotlin/pull/148