### PR TITLE
ENT-7765: Add TradeAndReportTwoStates Flow to observableStates-trader…

### DIFF
--- a/Features/observableStates-tradereporting/build.gradle
+++ b/Features/observableStates-tradereporting/build.gradle
@@ -46,6 +46,8 @@ allprojects { //Properties that you need to compile your project (The applicatio
         mavenCentral()
         maven { url 'https://download.corda.net/maven/corda-dependencies' }
         maven { url 'https://jitpack.io' }
+        maven { url 'https://download.corda.net/maven/corda-dev' }
+        maven { url 'https://download.corda.net/maven/r3-corda-dev' }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
@@ -120,7 +122,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
     }
     node {
-        name "O=Notary,L=London,C=GB"
+        name "O=Notary, L=London, C=GB"
         notary = [validating : false]
         p2pPort 10002
         rpcSettings {
@@ -130,7 +132,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         cordapps.clear()
     }
     node {
-        name "O=Seller,L=London,C=GB"
+        name "O=Seller, L=London, C=GB"
         p2pPort 10005
         rpcSettings {
             address("localhost:10006")
@@ -138,7 +140,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         }
     }
     node {
-        name "O=Buyer,L=New York,C=US"
+        name "O=Buyer, L=New York, C=US"
         p2pPort 10008
         rpcSettings {
             address("localhost:10009")
@@ -146,7 +148,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         }
     }
     node {
-        name "O=StateRegulator,L=New York,C=US"
+        name "O=StateRegulator, L=New York, C=US"
         p2pPort 10011
         rpcSettings {
             address("localhost:10012")
@@ -154,7 +156,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         }
     }
     node {
-        name "O=NationalRegulator,L=New York,C=US"
+        name "O=NationalRegulator, L=New York, C=US"
         p2pPort 10014
         rpcSettings {
             address("localhost:10015")

--- a/Features/observableStates-tradereporting/workflows/src/main/kotlin/net/corda/samples/observable/flows/TradeAndReportTwoStates.kt
+++ b/Features/observableStates-tradereporting/workflows/src/main/kotlin/net/corda/samples/observable/flows/TradeAndReportTwoStates.kt
@@ -1,0 +1,46 @@
+package net.corda.samples.observable.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.node.StatesToRecord
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.ProgressTracker
+import net.corda.samples.observable.contracts.HighlyRegulatedContract
+import net.corda.samples.observable.states.HighlyRegulatedState
+
+@InitiatingFlow
+@StartableByRPC
+class TradeAndReportTwoStates(val buyer: Party,
+                              val secondBuyer: Party,
+                              val stateRegulator: Party,
+                              val nationalRegulator: Party) : FlowLogic<Unit>() {
+    override val progressTracker = ProgressTracker()
+
+    @Suspendable
+    override fun call() {
+        val notary = serviceHub.networkMapCache.notaryIdentities[0]
+
+        val transactionBuilder = TransactionBuilder(notary)
+            .addOutputState(HighlyRegulatedState(buyer, ourIdentity), HighlyRegulatedContract.ID)
+            .addOutputState(HighlyRegulatedState(secondBuyer, ourIdentity), HighlyRegulatedContract.ID)
+            .addCommand(HighlyRegulatedContract.Commands.Trade(), ourIdentity.owningKey)
+
+        val signedTransaction = serviceHub.signInitialTransaction(transactionBuilder)
+
+        val sessions = listOf(initiateFlow(buyer), initiateFlow(secondBuyer), initiateFlow(stateRegulator))
+        // We distribute the transaction to both the buyer and the state regulator using `FinalityFlow`.
+        subFlow(FinalityFlow(signedTransaction, sessions))
+
+        // We also distribute the transaction to the national regulator manually.
+        subFlow(ReportManually(signedTransaction, nationalRegulator))
+    }
+}
+
+@InitiatedBy(TradeAndReportTwoStates::class)
+class TradeAndReportTwoStatesResponder(val counterpartySession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        subFlow(ReceiveFinalityFlow(counterpartySession, statesToRecord = StatesToRecord.ONLY_RELEVANT))
+    }
+}


### PR DESCRIPTION
Added TradeAndReportTwoStates Class in to observableStates-tradereporting Cordapp
as Required in testcase [ENT-7765](https://r3-cev.atlassian.net/browse/ENT-7765)
(For Corda 4.11)

[ENT-7765]: https://r3-cev.atlassian.net/browse/ENT-7765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ