### PR TITLE
ENT-15124: Update build.gradle for referenceStates-sanctionsBody & observableStates-tradereporting

### DIFF
--- a/Features/observableStates-tradereporting/build.gradle
+++ b/Features/observableStates-tradereporting/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     cordaCompile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
     cordaCompile "org.apache.logging.log4j:log4j-web:${log4j_version}"
     cordaCompile "org.slf4j:jul-to-slf4j:$slf4j_version"
-    cordaDriver "net.corda:corda-shell:4.9"
+    cordaDriver "net.corda:corda-shell:$corda_release_version"
 }
 
 //Task to build the jar for ganache.

--- a/Features/observableStates-tradereporting/repositories.gradle
+++ b/Features/observableStates-tradereporting/repositories.gradle
@@ -5,4 +5,9 @@ repositories {
     maven { url 'https://jitpack.io' }
     maven { url 'https://download.corda.net/maven/corda-dependencies' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+    maven {url 'https://software.r3.com/artifactory/corda-releases'
+        credentials {
+            username = findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+            password = findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+        }}
 }

--- a/Features/referenceStates-sanctionsBody/build.gradle
+++ b/Features/referenceStates-sanctionsBody/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     cordaCompile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
     cordaCompile "org.apache.logging.log4j:log4j-web:${log4j_version}"
     cordaCompile "org.slf4j:jul-to-slf4j:$slf4j_version"
-    cordaDriver "net.corda:corda-shell:4.9"
+    cordaDriver "net.corda:corda-shell:$corda_release_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {


### PR DESCRIPTION
Update build.gradle for referenceStates-sanctionsBody & observableStates-tradereporting which was using corda-shell version as `4.9 `
Make observableStates-tradereporting cordapp work on RC Version

[TradeReportingObservableStatesTests](https://ci05.dev.r3.com/job/QA/job/CRAFT4/job/Utility/job/Test-Executor/6607/testReport/net.craft.scenarios.democordapps/TradeReportingObservableStatesTests/)
[ReferenceStatesSanctionBodyTests](https://ci05.dev.r3.com/job/QA/job/CRAFT4/job/Utility/job/Test-Executor/6600/testReport/net.craft.scenarios.democordapps/ReferenceStatesSanctionBodyTests/) 